### PR TITLE
Replace tinygradient with homegrown class.

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -28,7 +28,6 @@
     "pino-pretty": "^3.5.0",
     "pngjs": "^3.4.0",
     "serialport": "^8.0.6",
-    "tinygradient": "^1.1.0",
     "ts-node": "^8.5.4",
     "tumult": "^3.0.14",
     "typescript": "^3.7.4",
@@ -38,7 +37,6 @@
     "@types/glob": "^7.1.1",
     "@types/node": "^13.1.4",
     "@types/pngjs": "^3.4.0",
-    "@types/tinycolor": "^1.1.27",
     "babel-cli": "^6.26.0",
     "eslint": "^6.8.0",
     "prettier": "^1.19.1"

--- a/server/src/light-programs/programs/bassWarpGrid.js
+++ b/server/src/light-programs/programs/bassWarpGrid.js
@@ -1,10 +1,9 @@
 const LayerBasedProgram = require("../base-programs/LayerBasedProgram");
 const { Grid, GradientColorize } = require("../utils/drawables");
-const _ = require('lodash');
+const _ = require("lodash");
 const gradients = require("../utils/gradients");
 
 module.exports = class Bombs extends LayerBasedProgram {
-
   init() {
     this.warpK = 1;
     this.bassWarpCenter = [this.xBounds.center, this.yBounds.center];
@@ -14,13 +13,13 @@ module.exports = class Bombs extends LayerBasedProgram {
     const grid = new Grid({ xyWarp: this.bassXYWarp.bind(this) });
     const colorizedGrid = new GradientColorize({
       drawable: grid,
-      gradient: 'tas04',
-      preserveAlpha: true,
-      invert: true,
+      gradient: "tas04",
+      preserveAlpha: false,
+      invert: true
     });
     return {
       grid: grid,
-      colorizedGrid: colorizedGrid,
+      colorizedGrid: colorizedGrid
     };
   }
   getLayers(drawables) {
@@ -79,9 +78,9 @@ module.exports = class Bombs extends LayerBasedProgram {
   static configSchema() {
     let res = super.configSchema();
     res.gradient = {
-      type: 'gradient',
+      type: "gradient",
       values: _.keys(gradients),
-      default: _.keys(gradients)[0],
+      default: _.keys(gradients)[0]
     };
     return res;
   }

--- a/server/src/light-programs/programs/radial.js
+++ b/server/src/light-programs/programs/radial.js
@@ -1,4 +1,4 @@
-const _ = require('lodash')
+const _ = require("lodash");
 
 const LightProgram = require("./../base-programs/LightProgram");
 const ColorUtils = require("./../utils/ColorUtils");
@@ -20,20 +20,20 @@ module.exports = class Radial extends LightProgram {
       const distance =
         (Math.sqrt(dx * dx + dy * dy) * 255) / (300 * this.config.escala);
 
-      const v = Math.max(
-        0,
-        Math.sin(distance + elapsed * this.config.velocidad)
+      const v = Math.pow(
+        Math.max(0, Math.sin(distance + elapsed * this.config.velocidad)),
+        this.config.power
       );
 
       const gradient = gradients[this.config.colorMap];
-      if(gradient) {
-        const {r,g,b,a} = gradient.rgbAt(1 - Math.pow(v, this.config.power)).toRgb()
-        colors[i] = [r,g,b]
+      if (gradient) {
+        const [r, g, b, a] = gradient.colorAt(1 - v);
+        colors[i] = [r, g, b];
       } else {
         colors[i] = ColorUtils.HSVtoRGB(
           (distance / 5 + this.extraTime / 1000) % 1,
-          1,
-          Math.pow(v, this.config.power)
+          0,
+          v
         );
       }
     }
@@ -48,7 +48,7 @@ module.exports = class Radial extends LightProgram {
     res.centerY = { type: Number, min: -20, max: 40, step: 0.1, default: 0 };
     res.centerX = { type: Number, min: -50, max: 50, step: 0.1, default: 0 };
     res.power = { type: Number, min: 0, max: 10, step: 0.1, default: 1 };
-    res.colorMap =  {type: 'gradient', values: _.keys(gradients), default: ''};
+    res.colorMap = { type: "gradient", values: _.keys(gradients), default: "" };
 
     return res;
   }

--- a/server/src/light-programs/utils/ColorUtils.d.ts
+++ b/server/src/light-programs/utils/ColorUtils.d.ts
@@ -1,0 +1,1 @@
+export function rgbToHex(r: number, g: number, b: number): string;

--- a/server/src/light-programs/utils/drawables.js
+++ b/server/src/light-programs/utils/drawables.js
@@ -1,5 +1,5 @@
 const ColorUtils = require("./ColorUtils");
-const gradients = require('./gradients');
+const gradients = require("./gradients");
 
 class Drawable {
   colorAtIndex(index, geometry) {}
@@ -10,22 +10,25 @@ class GradientColorize extends Drawable {
     options = options || {};
     super(options);
     this.drawable = options.drawable;
-    this.value = options.value || 'alphaluminance';
+    this.value = options.value || "alphaluminance";
     this.gradient = options.gradient;
     this.preserveAlpha = !!options.preserveAlpha;
     this.invert = !!options.invert;
   }
   set gradient(gradient) {
+    if (!gradient) {
+      return;
+    }
     this._gradient = gradients[gradient] || gradient;
   }
   set value(value) {
-    if (value == 'alpha') {
+    if (value == "alpha") {
       this.getValue = this._getAlpha;
-    } else if (value == 'luminance') {
+    } else if (value == "luminance") {
       this.getValue = color => ColorUtils.luminance(...color) / 255;
-    } else if (value == 'alphaluminance') {
+    } else if (value == "alphaluminance") {
       this.getValue = color => {
-        return this._getAlpha(color) * ColorUtils.luminance(...color) / 255;
+        return (this._getAlpha(color) * ColorUtils.luminance(...color)) / 255;
       };
     } else {
       this.getValue = value;
@@ -43,8 +46,8 @@ class GradientColorize extends Drawable {
     if (this.invert) {
       value = 1 - value;
     }
-    const {r, g, b, a} = this._gradient.rgbAt(value).toRgb();
-    const newColor = [r, g, b, this.preserveAlpha? color[3] : a];
+    const [r, g, b, a] = this._gradient.colorAt(value);
+    const newColor = [r, g, b, this.preserveAlpha ? color[3] : a];
     return newColor;
   }
 }

--- a/server/src/light-programs/utils/gradients.ts
+++ b/server/src/light-programs/utils/gradients.ts
@@ -1,11 +1,55 @@
-import fs from 'fs';
-import glob from 'glob';
-import path from 'path';
-import {PNG} from 'pngjs';
-import tinycolor from 'tinycolor2';
-import tinygradient from 'tinygradient';
+import fs from "fs";
+import glob from "glob";
+import path from "path";
+import { PNG } from "pngjs";
+import { rgbToHex } from "./ColorUtils";
 
-const gradientsByName: {[index: string]: tinygradient.Instance} = {};
+type Color = [number, number, number, number];
+
+function interpolate(a: Color, b: Color, blend: number) {
+  if (blend < 0 || blend > 1) {
+    throw `blend out of bounds: ${blend}`;
+  }
+  // TODO: implement interpolation.
+  return blend < 0.5 ? a : b;
+}
+
+abstract class Gradient {
+  abstract colorAt(pos: number): Color;
+  abstract reverse(): Gradient;
+  abstract cssLinearGradientStops(): string;
+}
+
+class EvenSpacedGradient extends Gradient {
+  colors: Color[];
+  constructor(colors: Color[]) {
+    super();
+    if (colors.length == 0) {
+      throw "Need at least one color";
+    }
+    this.colors = colors;
+  }
+  colorAt(pos: number): Color {
+    if (pos < 0 || pos > 1) {
+      throw `pos out of bounds: ${pos}`;
+    }
+    const scaledPos = pos * (this.colors.length - 1);
+    const lowerIndex = Math.floor(scaledPos);
+    const upperIndex = Math.ceil(scaledPos);
+    const blend = scaledPos - lowerIndex;
+    return interpolate(this.colors[lowerIndex], this.colors[upperIndex], blend);
+  }
+  reverse() {
+    return new EvenSpacedGradient(Array.from(this.colors).reverse());
+  }
+  cssLinearGradientStops() {
+    return this.colors
+      .map(color => rgbToHex(color[0], color[1], color[2]))
+      .join(", ");
+  }
+}
+
+const gradientsByName: { [index: string]: Gradient } = {};
 
 function gradientFromPng(filename: string) {
   var data = fs.readFileSync(filename);
@@ -14,29 +58,27 @@ function gradientFromPng(filename: string) {
     throw `Width or height must be 1, found: ${png.width}, ${png.height}.`;
   }
   const size = Math.max(png.width, png.height);
-  const colors = new Array(size);
+  const colors: Color[] = new Array(size);
   for (let i = 0; i < size; i++) {
     const offset = 4 * i;
-    colors[i] = tinycolor({
-      r: png.data[offset],
-      g: png.data[offset + 1],
-      b: png.data[offset + 2],
-      a: png.data[offset + 3],
-    });
+    colors[i] = [
+      png.data[offset],
+      png.data[offset + 1],
+      png.data[offset + 2],
+      png.data[offset + 3]
+    ];
   }
-  return tinygradient(colors);
+  return new EvenSpacedGradient(colors);
 }
 
-const gradientFiles = glob.sync(path.join(__dirname, 'gradientlib', '*'));
+const gradientFiles = glob.sync(path.join(__dirname, "gradientlib", "*"));
 gradientFiles.forEach(filename => {
   const extension = path.extname(filename);
   const name = path.basename(filename, extension);
-  let gradient: tinygradient.Instance = null;
-  if (extension.toLowerCase() == '.png') {
-    gradient = gradientFromPng(filename);
-  }
-  if (gradient != null) {
+  if (extension.toLowerCase() == ".png") {
+    const gradient = gradientFromPng(filename);
     gradientsByName[name] = gradient;
+    gradientsByName[`${name}_r`] = gradient.reverse();
   }
 });
 

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -120,16 +120,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/tinycolor2@^1.4.0":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@types/tinycolor2/-/tinycolor2-1.4.2.tgz#721ca5c5d1a2988b4a886e35c2ffc5735b6afbdf"
-  integrity sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw==
-
-"@types/tinycolor@^1.1.27":
-  version "1.1.27"
-  resolved "https://registry.yarnpkg.com/@types/tinycolor/-/tinycolor-1.1.27.tgz#d01d05a681d0ce28923b021d5f3d752ea0478089"
-  integrity sha1-0B0FpoHQziiSOwIdXz11LqBHgIk=
-
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -2703,19 +2693,6 @@ through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-
-tinycolor2@^1.0.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
-  integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
-
-tinygradient@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/tinygradient/-/tinygradient-1.1.0.tgz#cf5c21bcb9180540707d06dbaa8c10cf8ead7f29"
-  integrity sha512-aY40P8+QrHt78zpQo7LG5AXpQcZDNmam35nVkxeXVHEAr6HaVPgsEl7Lf/DcnCuuMAfiuK0fmsQmTtD1FmwI9w==
-  dependencies:
-    "@types/tinycolor2" "^1.4.0"
-    tinycolor2 "^1.0.0"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
tinygradient was causing weird glitches. Implemented an internal
gradient class.

Also duplicate all gradients with a convenience "_r" suffixed reverse
version.

Note: gradient class has a cssLinearGradientStops() method. Use like
this to replace backgroundImage in the picker:

```css
linear-gradient(to right, ${gradient.cssLinearGradientStops()});
```