### PR TITLE
Programs as subparameters, save presets and more

### DIFF
--- a/server/src/LightsService.js
+++ b/server/src/LightsService.js
@@ -71,18 +71,14 @@ module.exports = class LightsService {
   }
 
   setPreset(presetName) {
-    const controller = this.controller;
-    const presets = controller.getCurrentPresets();
-
-    if (!presets[presetName]) {
-      console.warn(`Selected preset ${presetName} not found.`)
-      return;
-    }
-
-    controller.currentProgram.updateConfig(
-        _.extend(controller.getConfig(), presets[presetName]));
-
+    this.controller.setPreset(presetName);
     this.broadcastStateChange();
+  }
+
+  savePreset({programName, presetName, currentConfig}) {
+    this.controller.savePreset(programName, presetName, currentConfig);
+    this.setPreset(presetName)
+    console.log("Saved new preset", programName, presetName, currentConfig)
   }
 
   setCurrentProgram(programKey) {
@@ -92,7 +88,8 @@ module.exports = class LightsService {
 
   updateConfigParam(config) {
     const controller = this.controller;
-    controller.currentProgram.updateConfig(config);
+
+    controller.updateConfigOverride(config);
 
     this.send("stateChange", {
       currentProgramName : controller.currentProgramName,

--- a/server/src/light-programs/base-programs/LightProgram.js
+++ b/server/src/light-programs/base-programs/LightProgram.js
@@ -1,9 +1,10 @@
 module.exports = class LightProgram {
-  constructor(config, geometry, shapeMapping) {
+  constructor(config, geometry, shapeMapping, lightController) {
     this.config = config;
     this.geometry = geometry;
     this.shapeMapping = shapeMapping;
     this.numberOfLeds = geometry.leds;
+    this.lightController = lightController;
   }
 
   init() {}

--- a/server/src/light-programs/base-programs/ProgramsByShape.js
+++ b/server/src/light-programs/base-programs/ProgramsByShape.js
@@ -24,6 +24,7 @@ module.exports = function programsByShape(mapping) {
         const shape = {
           x: [...Array(map.length)],
           y: [...Array(map.length)],
+          z: [...Array(map.length)],
           height: geometry.height,
           width: geometry.width,
           leds: map.length
@@ -32,6 +33,7 @@ module.exports = function programsByShape(mapping) {
         for (let i = 0; i < map.length; i++) {
           shape.x[i] = geometry.x[map[i]];
           shape.y[i] = geometry.y[map[i]];
+          shape.z[i] = geometry.z[map[i]];
         }
 
         // Support specific configs

--- a/server/src/light-programs/programs/lineal.js
+++ b/server/src/light-programs/programs/lineal.js
@@ -1,6 +1,8 @@
 const LightProgram = require("./../base-programs/LightProgram");
 const ColorUtils = require("./../utils/ColorUtils");
 
+const {loadGradient} = require("../utils/gradients");
+
 module.exports = class Lineal extends LightProgram {
   drawFrame(draw) {
     const colors = new Array(this.numberOfLeds);
@@ -22,11 +24,15 @@ module.exports = class Lineal extends LightProgram {
         0,
         Math.sin(distance + elapsed * this.config.velocidad)
       );
-      colors[i] = ColorUtils.HSVtoRGB(
-        (distance / 50 + this.extraTime / 1000) % 1,
-        1,
-        Math.pow(v, this.config.power)
-      );
+
+      const brightness = Math.pow(v, this.config.power);
+      if (this.config.colorMap) {
+        const gradient = loadGradient(this.config.colorMap);
+        colors[i] = gradient.colorAt(1-brightness);
+      } else {
+        colors[i] = ColorUtils.HSVtoRGB((distance / 50 + this.extraTime / 1000) % 1, 1, brightness);
+      }
+
     }
     draw(colors);
   }
@@ -56,6 +62,7 @@ module.exports = class Lineal extends LightProgram {
     res.centerY = { type: Number, min: -20, max: 40, step: 0.1, default: 0 };
     res.centerX = { type: Number, min: -80, max: 80, step: 0.1, default: -80 };
     res.power = { type: Number, min: 0, max: 30, step: 0.1, default: 10 };
+    res.colorMap = { type: "gradient", default: "" };
     res.horizontal = { type: Boolean, default: false };
     return res;
   }

--- a/server/src/light-programs/programs/mix.js
+++ b/server/src/light-programs/programs/mix.js
@@ -1,0 +1,102 @@
+const LightProgram = require("./../base-programs/LightProgram");
+const ColorUtils = require("./../utils/ColorUtils");
+const _ = require('lodash');
+
+const {loadGradient} = require("../utils/gradients");
+
+module.exports = class Mix extends LightProgram {
+  init() {
+    let {a, b} = this.config;
+
+    this.subprograms = [
+      this.getProgramInstanceFromParam(a),
+      this.getProgramInstanceFromParam(b)
+    ]
+  }
+
+  getProgramInstanceFromParam({programName, config}) {
+    let p = this.lightController.instanciateProgram(programName);
+    p.updateConfig({...p.config, ...config})
+    p.init();
+    return p;
+  }
+
+  drawFrame(draw, audio) {
+    const combinedColors = new Array(this.numberOfLeds);
+
+    this.extraTime = (this.extraTime || 0) + Math.random() * 10;
+
+    for (const prog of this.subprograms) {
+      // Done by ProgramScheduler, has to be replicated here
+      prog.timeInMs = this.timeInMs;
+      let globalBrightness = prog.config.globalBrightness || 0;
+      prog.drawFrame((colors) => {
+        for (let i = 0; i < this.numberOfLeds; i++) {
+          let [r, g, b, a] = combinedColors[i] || [0, 0, 0, 0];
+          const [r2, g2, b2, a2] = colors[i];
+          r += (r2 || 0)*globalBrightness;
+          g += (g2 || 0)*globalBrightness;
+          b += (b2 || 0)*globalBrightness;
+          a += a2 || 0;
+          combinedColors[i] = [r, g, b, a];
+        }
+      }, audio)
+    }
+    draw(combinedColors);
+  }
+
+  updateConfig(newConfig) {
+    // Override LightProgram version to decide when a program init needs to be called
+    if (this.subprograms) {
+      let updated = [newConfig.a, newConfig.b];
+      let oldConfigs = [this.config.a, this.config.b]
+
+      this.subprograms = _.map(updated, (newProgDef, i) => {
+        let oldProgDef = oldConfigs[i];
+
+        let subprogram = null;
+
+        if (oldProgDef && oldProgDef.programName === newProgDef.programName) {
+          subprogram = this.subprograms[i]
+          subprogram.updateConfig({ ... subprogram.config, ... newProgDef.config })
+        } else {
+          subprogram = this.getProgramInstanceFromParam(newProgDef)
+        }
+
+        if(oldProgDef.presetName !== newProgDef.presetName) {
+          const presets = this.lightController.getProgramPresets(newProgDef.programName);
+          const defaults = {}
+          newProgDef.config = presets[newProgDef.presetName];
+          subprogram.updateConfig({ ... defaults, ... subprogram.config, ... presets[newProgDef.presetName] })
+        }
+
+        return subprogram
+      })
+    }
+
+    super.updateConfig(newConfig)
+  }
+
+  static presets() {
+    return {
+      radialStars: {
+        a: {programName: 'stars'},
+        b: {
+          programName: 'radial', config: {
+            velocidad: 20
+          }
+        }
+      },
+    };
+  }
+
+  // Override and extend config Schema
+  static configSchema() {
+    let res = super.configSchema();
+
+    res.a = {type: 'program', default: {programName: 'all-off'}};
+    res.b = {type: 'program', default: {programName: 'all-off'}};
+
+    return res;
+  }
+};

--- a/server/src/light-programs/programs/radialSun.js
+++ b/server/src/light-programs/programs/radialSun.js
@@ -88,8 +88,8 @@ module.exports = class RadialSun extends LightProgram {
   // Override and extend config Schema
   static configSchema() {
     let res = super.configSchema();
-    res.escala = { type: Number, min: 1, max: 100, step: 1, default: 70 };
-    res.centerY = { type: Number, min: -20, max: 40, step: 0.1, default: 0 };
+    res.escala = { type: Number, min: 1, max: 200, step: 1, default: 70 };
+    res.centerY = { type: Number, min: -40, max: 80, step: 0.1, default: 0 };
     res.centerX = { type: Number, min: -50, max: 50, step: 0.1, default: 0 };
     res.power = { type: Number, min: 0, max: 10, step: 0.1, default: 3 };
     res.saturation = { type: Number, min: 0, max: 1, step: 0.01, default: 1 };

--- a/server/src/light-programs/programs/rays.js
+++ b/server/src/light-programs/programs/rays.js
@@ -18,7 +18,7 @@ module.exports = class Rays extends LightProgram {
     let speed = ray.speed * this.config.globalSpeed * ray.direction;
     if (this.config.useSoundSpeed) {
       // let vol = Math.max(0.1, audio.averageRelativeVolume - 0.2);
-      speed *= (audio.bassFastPeakDecay || 0) * 3;
+      speed *= (audio.bassPeakDecay || 0) * 3;
     }
     ray.pos += speed;
   }

--- a/server/src/light-programs/programs/sound-waves.js
+++ b/server/src/light-programs/programs/sound-waves.js
@@ -93,94 +93,31 @@ module.exports = class SoundWaves extends LightProgram {
 
   static presets() {
     return {
-      hexagono: {
-        initialDistance: 69,
-        haciaAfuera: false,
-        waveSpeed: 1,
-        waveWidth: 2
-      },
-      default: { waveCenterY: 0 },
-      deLasPuntas: {
-        waveSpeed: 1,
-        waveWidth: 2,
-        initialDistance: 40,
-        haciaAfuera: false,
-        brilloWave: 0.5
-      },
-      centroLento: { waveSpeed: 0.1 },
-      centroLentoDark: { waveSpeed: 0.1, brilloWave: 0.25 },
-      centroFast: { waveSpeed: 3 },
-      centroDots: { waveSpeed: 2, waveWidth: 0.5 },
-      centroBrightFast: {
-        waveSpeed: 0.7,
-        brilloWave: 2,
-        waveWidth: 1,
-        waveCenterY: -17.3
-      },
-      abajoFast: { waveCenterY: -17.3, waveSpeed: 3, waveWidth: 3 },
-      xInvertida: { initialDistance: 15, haciaAfuera: false },
-      deArribaAbajo: {
-        initialDistance: 67,
-        waveCenterY: -40,
-        haciaAfuera: false,
-        waveSpeed: 2
-      }
+      hexagono: {initialDistance: 69, haciaAfuera: false, waveSpeed: 1, waveWidth: 2},
+      default: {waveCenterY: 0},
+      deLasPuntas: {waveSpeed: 1, waveWidth: 2, initialDistance: 40, haciaAfuera: false, brilloWave: 0.5},
+      centroLento: {waveSpeed: 0.1},
+      centroLentoDark: {waveSpeed: 0.1, brilloWave: 0.25},
+      centroFast: {waveSpeed: 3},
+      centroDots: {waveSpeed: 2, waveWidth: 0.5},
+      centroBrightFast: {waveSpeed: 0.7, brilloWave: 2, waveWidth: 1, waveCenterY: -17.3},
+      abajoFast: {waveCenterY: -17.3, waveSpeed: 3, waveWidth: 3},
+      xInvertida: {initialDistance: 15, haciaAfuera: false},
+      deArribaAbajo: {initialDistance: 67, waveCenterY: -40, haciaAfuera: false, waveSpeed: 2}
     };
   }
 
   static configSchema() {
     let config = super.configSchema();
 
-    config.brilloWave = {
-      type: Number,
-      min: 0,
-      max: 3,
-      step: 0.01,
-      default: 0.5
-    };
-    config.initialDistance = {
-      type: Number,
-      min: 0,
-      max: 100,
-      step: 0.1,
-      default: 0
-    };
-    config.waveCenterY = {
-      type: Number,
-      min: -40,
-      max: 40,
-      step: 1,
-      default: 0
-    };
-    config.waveCenterX = {
-      type: Number,
-      min: -60,
-      max: 60,
-      step: 1,
-      default: 0
-    };
-    config.waveWidth = {
-      type: Number,
-      min: 0,
-      max: 10,
-      step: 0.1,
-      default: 2.5
-    };
-    config.waveSpeed = {
-      type: Number,
-      min: 0.1,
-      max: 10,
-      step: 0.1,
-      default: 1
-    };
-    config.haciaAfuera = { type: Boolean, default: true };
-    config.wavePower = {
-      type: Number,
-      min: 0.5,
-      max: 10,
-      step: 0.5,
-      default: 1.2
-    };
+    config.brilloWave = {type: Number, min: 0, max: 3, step: 0.01, default: 0.5};
+    config.initialDistance = {type: Number, min: 0, max: 100, step: 0.1, default: 0};
+    config.waveCenterY = {type: Number, min: -40, max: 40, step: 1, default: 0};
+    config.waveCenterX = {type: Number, min: -60, max: 60, step: 1, default: 0};
+    config.waveWidth = {type: Number, min: 0, max: 10, step: 0.1, default: 2.5};
+    config.waveSpeed = {type: Number, min: 0.1, max: 10, step: 0.1, default: 1};
+    config.haciaAfuera = {type: Boolean, default: true};
+    config.wavePower = {type: Number, min: 0.5, max: 10, step: 0.5, default: 1.2};
     // config.colorHueOffset = {type: Number, min: 0, max: 1, step: 0.01, default: 0}
 
     // config.musicWeight = {type: Number, min: 0, max: 5, step: 0.1, default: 1}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,7 +5,6 @@ import { DevicesStatus } from "./DevicesStatus";
 import { LightsSimulator } from "./LightsSimulator";
 import { MicrophoneViewer } from "./MicrophoneViewer";
 import { ProgramList } from "./ProgramList";
-import { ProgramConfig } from "./ProgramConfig";
 import {
   Program,
   ConfigValue,
@@ -13,16 +12,18 @@ import {
   MicSample,
   RemoteState,
   RemoteLayout,
-  Device
+  Device,
+  CurrentProgramParameters
 } from "./types";
 import { API } from "./api";
+import { TopProgramConfig } from "./TopProgramConfig";
 
 interface Props {}
 
 interface State {
   selected: string | null;
   programs: { [name: string]: Program };
-  currentConfig: { [param: string]: ConfigValue } | null;
+  currentConfig: CurrentProgramParameters;
   globalConfig: { [param: string]: any };
   micConfig: MicConfig;
   remoteChange: boolean;
@@ -42,7 +43,7 @@ export class App extends React.Component<Props, State> {
     this.state = {
       selected: null,
       programs: {},
-      currentConfig: null,
+      currentConfig: {},
       globalConfig: {},
       micConfig: {
         sendingMicData: false,
@@ -76,7 +77,7 @@ export class App extends React.Component<Props, State> {
       remoteChange: true
     });
 
-    console.log(state.currentProgramName, state);
+    // console.log(state.currentProgramName, state);
   }
 
   componentDidMount() {
@@ -149,7 +150,7 @@ export class App extends React.Component<Props, State> {
       // TODO: added to typecheck, check if it's right
       if (newState.currentConfig) {
         console.log("ENTIRE CHANGING TO", newState.currentConfig);
-        this.api.updateConfigParam(newState.currentConfig);
+        this.api.updateConfigParam(newState.currentConfig.overrides || {});
       }
     }
   }
@@ -193,6 +194,10 @@ export class App extends React.Component<Props, State> {
     this.api.stopSamplingLights();
   };
 
+  handleSaveNewPreset = (programName: string, presetName: string, presetConfig: { [param: string]: ConfigValue }) => {
+    this.api.savePreset(programName, presetName, presetConfig);
+  }
+
   render() {
     let currentProgram = this.getCurrentProgram();
 
@@ -213,12 +218,14 @@ export class App extends React.Component<Props, State> {
               />
             </nav>
             <div className="controlsbar overflow-auto p-3">
-              <ProgramConfig
+              <TopProgramConfig
                 program={currentProgram}
                 selected={this.state.selected}
                 config={this.state.currentConfig}
                 globalConfig={this.state.globalConfig}
+                programs={this.state.programs}
                 onSelectPreset={this.selectPreset}
+                onSaveNewPreset={this.handleSaveNewPreset}
                 onRestartProgram={this.restartProgram}
                 onChangeProgramConfig={this.handleChangeProgramConfig}
               />

--- a/web/src/BooleanParam.tsx
+++ b/web/src/BooleanParam.tsx
@@ -3,12 +3,12 @@ import React from "react";
 interface Props {
   name: string;
   value: boolean;
-  onChange(e: React.SyntheticEvent, name: string, value: boolean): void;
+  onChange(name: string, value: boolean): void;
 }
 export class BooleanParam extends React.Component<Props> {
   handleChange = (event: React.SyntheticEvent<HTMLInputElement>) => {
     let value = (event.target as any).checked as boolean;
-    this.props.onChange(event, this.props.name, value);
+    this.props.onChange(this.props.name, value);
   };
 
   render() {

--- a/web/src/GradientParam.tsx
+++ b/web/src/GradientParam.tsx
@@ -5,13 +5,13 @@ interface Props {
   name: string;
   value: string;
   options: { [key: string]: string };
-  onChange(e: React.SyntheticEvent, name: string, value: string): void;
+  onChange(name: string, value: string): void;
 }
 
 export class GradientParam extends React.Component<Props> {
   handleChange = (event: React.SyntheticEvent, value: string) => {
     event.preventDefault();
-    this.props.onChange(event, this.props.name, value);
+    this.props.onChange(this.props.name, value);
   };
 
   render() {
@@ -26,7 +26,7 @@ export class GradientParam extends React.Component<Props> {
       // Assume value was a string with css stops
       stops = stops || value;
     } else {
-      stops = "#00000000,#00000000"
+      stops = "#000000,#000000"
       name = "None"
     }
 
@@ -38,8 +38,10 @@ export class GradientParam extends React.Component<Props> {
           <div className="float-right font-weight-bold">
             <div className="dropdown">
               <button className="btn btn-sm btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton"
-                      data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-boundary={"window"}>
-                {name} <span className={`gradient-tas mr-2 d-inline-block`} style={gradientCss(stops)}>&nbsp;</span>
+                      data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span className={`gradient-tas mr-2 d-inline-block`} style={gradientCss(stops)}>&nbsp;</span>
+                <br/>
+                <span className={'small'}>{name}</span>
               </button>
               <div className="dropdown-menu gradient-dropdown" aria-labelledby="dropdownMenuButton">
 
@@ -48,7 +50,7 @@ export class GradientParam extends React.Component<Props> {
                   None
                 </button>
 
-                {_.map(_.toPairs(options).sort(), ([gradientName,gradientStops]) => (
+                {_.map(_.toPairs(options).sort(), ([gradientName, gradientStops]) => (
                   <button
                     key={gradientName}
                     className={`small dropdown-item ${gradientName === value ? "active" : ""}`}
@@ -63,6 +65,7 @@ export class GradientParam extends React.Component<Props> {
             </div>
           </div>
         </div>
+        <div className={'clearfix'}></div>
       </div>
     );
   }

--- a/web/src/LightsSimulator.tsx
+++ b/web/src/LightsSimulator.tsx
@@ -237,7 +237,7 @@ abstract class LightsRenderer {
 class Canvas3DLightsRenderer extends LightsRenderer {
   _projectedLeds: vec3[] | null = null;
   _scale = 1;
-  _xAngle = 0.3;
+  _xAngle = 0;
   _yAngle = 0;
   _frontArrowPoints: vec3[] | null = null;
 
@@ -326,12 +326,13 @@ class Canvas3DLightsRenderer extends LightsRenderer {
       layout.geometryZ
     ).map(led => vec3.transformMat4(vec3.create(), led as number[], transform));
 
-    const arrowWidth = Math.max(width, height, depth) / 100;
-    const arrowLength = 4 * arrowWidth;
+    const arrowLength = Math.max(width, height, depth) / 30;
+    const [cX, cY, cZ] = [layout.maxX - arrowLength, layout.maxY, centerZ];
     const arrowPoints = [
-      vec3.fromValues(centerX - arrowWidth / 2, layout.maxY, centerZ),
-      vec3.fromValues(centerX + arrowWidth / 2, layout.maxY, centerZ),
-      vec3.fromValues(centerX, layout.maxY, centerZ - arrowLength),
+      vec3.fromValues(cX, cY, cZ),
+      vec3.fromValues(cX + arrowLength, cY, cZ),
+      vec3.fromValues(cX, cY - arrowLength, cZ),
+      vec3.fromValues(cX, cY, cZ - arrowLength),
     ];
     this._frontArrowPoints = arrowPoints.map(
         point => vec3.transformMat4(vec3.create(), point, transform));
@@ -350,21 +351,13 @@ class Canvas3DLightsRenderer extends LightsRenderer {
     }
     const ctx = canvas.getContext("2d")!;
 
+    // Draw leds.
     ctx.globalCompositeOperation = "source-over";
     ctx.fillStyle = "black";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
     ctx.globalCompositeOperation = "lighter";
 
-    // Draw red arrow pointing front (to help with orientation).
-    ctx.fillStyle = "red";
-    ctx.beginPath();
-    ctx.moveTo(this._frontArrowPoints![0][0], this._frontArrowPoints![0][1]);
-    ctx.lineTo(this._frontArrowPoints![1][0], this._frontArrowPoints![1][1]);
-    ctx.lineTo(this._frontArrowPoints![2][0], this._frontArrowPoints![2][1]);
-    ctx.fill();
-
-    // Draw leds.
     const leds = this.projectedLeds.length;
 
     for (let i = 0; i < leds; i++) {
@@ -398,6 +391,29 @@ class Canvas3DLightsRenderer extends LightsRenderer {
       ctx.arc(x, y, lightRadius, 0, Math.PI * 2, false);
       ctx.fill();
     }
+
+    // Draw red arrow pointing front (to help with orientation).
+    let [center, x, y,z] = this._frontArrowPoints!;
+
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = "red";
+    ctx.beginPath();
+    ctx.moveTo(center[0], center[1]);
+    ctx.lineTo(x[0], x[1]);
+    ctx.stroke();
+
+    ctx.strokeStyle = "green";
+    ctx.beginPath();
+    ctx.moveTo(center[0], center[1]);
+    ctx.lineTo(y[0], y[1]);
+    ctx.stroke();
+
+    ctx.strokeStyle = "blue";
+    ctx.beginPath();
+    ctx.moveTo(center[0], center[1]);
+    ctx.lineTo(z[0], z[1]);
+    ctx.stroke();
+
 
     // this.xAngle += 0.005;
     // this.yAngle += 0.01;

--- a/web/src/NumberParam.tsx
+++ b/web/src/NumberParam.tsx
@@ -6,13 +6,13 @@ interface Props {
   min: number;
   step: number;
   max: number;
-  onChange(e: React.SyntheticEvent, name: string, value: number): void;
+  onChange(name: string, value: number): void;
 }
 
 export class NumberParam extends React.Component<Props> {
   handleChange = (event: React.SyntheticEvent<HTMLInputElement>) => {
     let value = (event.target as any).valueAsNumber;
-    this.props.onChange(event, this.props.name, value);
+    this.props.onChange(this.props.name, value);
   };
 
   render() {
@@ -22,7 +22,7 @@ export class NumberParam extends React.Component<Props> {
           <div className="float-left">{this.props.name}</div>
           <div className="float-right font-weight-bold">{this.props.value}</div>
         </div>
-        <div>
+        <div style={{marginTop: '-8px'}}>
           <input
             type="range"
             min={this.props.min}

--- a/web/src/ProgramConfig.tsx
+++ b/web/src/ProgramConfig.tsx
@@ -2,50 +2,52 @@ import React from "react";
 import { StringParam } from "./StringParam";
 import { BooleanParam } from "./BooleanParam";
 import { NumberParam } from "./NumberParam";
-import { Program, ConfigValue } from "./types";
+import { Program, ConfigValue, CurrentProgramParameters } from "./types";
 import { GradientParam } from "./GradientParam";
+import { SubprogramParam } from "./SubprogramParam";
 
 interface Props {
   program: Program | null;
-  selected: string | null;
-  config: { [param: string]: ConfigValue } | null;
+  programs: any;
+  config: CurrentProgramParameters;
   globalConfig: { [param: string]: any };
   onSelectPreset(name: string): void;
-  onRestartProgram(): void;
+  onSaveNewPreset(programName: string, presetName: string, presetConfig: { [param: string]: ConfigValue }): void;
   onChangeProgramConfig(config: { [name: string]: ConfigValue }): void;
 }
 
-export class ProgramConfig extends React.Component<Props> {
-  handleRestartProgram(e: React.SyntheticEvent) {
-    e.preventDefault();
-    this.props.onRestartProgram();
-  }
-
+export class ProgramConfig extends React.PureComponent<Props> {
   handleParamChange = (
-    e: React.SyntheticEvent,
     field: string,
     value: ConfigValue
   ) => {
-    let config = this.props.config;
-
-    if (!config) {
-      throw new Error("attempting to update null config");
-    }
-
-    config = Object.assign({}, config, { [field]: value });
-    this.props.onChangeProgramConfig(config);
+    this.props.onChangeProgramConfig({ [field]: value });
   };
+
+  handleSavePreset = (presetName: string | null | undefined) => {
+    if(this.props.config.presetOverrides && this.props.program) {
+      let newPresetName = presetName || prompt("Enter preset name");
+      if (newPresetName) {
+        let combinedParams = { ...this.props.config.presetOverrides, ...this.props.config.overrides };
+        this.props.onSaveNewPreset(this.props.program.name, newPresetName, combinedParams)
+      }
+    }
+  }
 
   render() {
     const currentProgram = this.props.program;
-    const currentConfig = this.props.config;
     const globalConfig = this.props.globalConfig;
 
+    const { currentPreset, defaults, overrides, presetOverrides } = this.props.config;
+    let currentConfig: { [index: string]: ConfigValue } = { ...defaults, ...presetOverrides, ...overrides };
+
     if (!currentProgram || !currentConfig) {
+      console.log("returned")
       return null;
     }
 
     let configOptions = [];
+
 
     for (let paramName in currentProgram.config) {
       let configDef = currentProgram.config[paramName] as any;
@@ -53,70 +55,79 @@ export class ProgramConfig extends React.Component<Props> {
 
       let typeName = configDef.type || typeof configDef.default;
 
+      let parameterEditor = null;
       switch (typeName) {
         case "boolean":
-          configOptions.push(
-            <BooleanParam
-              key={paramName}
-              name={paramName}
-              value={value as boolean}
-              onChange={this.handleParamChange}
-            />
-          );
+          parameterEditor = <BooleanParam
+            key={paramName}
+            name={paramName}
+            value={value as boolean}
+            onChange={this.handleParamChange}/>
           break;
         case "string":
-          configOptions.push(
-            <StringParam
-              key={paramName}
-              name={paramName}
-              value={value as string}
-              options={configDef.values}
-              onChange={this.handleParamChange}
-            />
-          );
+          parameterEditor = <StringParam
+            key={paramName}
+            name={paramName}
+            value={value as string}
+            options={configDef.values}
+            onChange={this.handleParamChange}/>
           break;
         case "gradient":
-          configOptions.push(
-            <GradientParam
-              key={paramName}
-              name={paramName}
-              value={value as string}
-              options={globalConfig.gradientsLibrary || {}}
-              onChange={this.handleParamChange}
-            />
-          );
+          parameterEditor = <GradientParam
+            key={paramName}
+            name={paramName}
+            value={value as string}
+            options={globalConfig.gradientsLibrary || {}}
+            onChange={this.handleParamChange}
+          />
+          break;
+        case "program":
+          parameterEditor = <SubprogramParam
+            key={paramName}
+            name={paramName}
+            value={value}
+            globalConfig={globalConfig}
+            options={this.props.programs}
+            onChange={this.handleParamChange}/>
           break;
         default:
-          configOptions.push(
-            <NumberParam
-              key={paramName}
-              name={paramName}
-              value={value as number}
-              step={configDef.step}
-              min={configDef.min}
-              max={configDef.max}
-              onChange={this.handleParamChange}
-            />
-          );
+          parameterEditor = <NumberParam
+            key={paramName}
+            name={paramName}
+            value={value as number}
+            step={configDef.step}
+            min={configDef.min}
+            max={configDef.max}
+            onChange={this.handleParamChange}/>
       }
+
+      let paramStateClass = (overrides && overrides[paramName]) ? 'text-warning' : (presetOverrides && presetOverrides[paramName] ? 'text-info' : 'text-secondary');
+
+      configOptions.push(<div key={paramName} className={paramStateClass}>{parameterEditor}</div>);
     }
 
     const presets = currentProgram.presets || [];
 
+    const addNewBtn = <button className="btn btn-sm btn-link mt-2" onClick={() => this.handleSavePreset(null)}>
+      Save as preset...
+    </button>
+
+    let overridePresetBtn = null;
+    if(currentPreset) {
+      overridePresetBtn = <button className="btn btn-sm btn-link mt-2 ml-3"
+                                  onClick={() => this.handleSavePreset(currentPreset)}>
+        Save to <span className={'text-info'}>'{currentPreset}'</span>
+      </button>
+    }
+
     return (
       <div>
-        <h5 className="">
-          {currentProgram.name} &nbsp;
-          <button
-            className="btn btn-sm btn-outline-secondary"
-            onClick={this.handleRestartProgram.bind(this)}
-          >
-            Restart
-          </button>
-        </h5>
-        <Presets presets={presets} onSelect={this.props.onSelectPreset} />
-        <hr />
+        <Presets presets={presets} selected={currentPreset} onSelect={this.props.onSelectPreset} />
         <div>{configOptions}</div>
+        <div className={'text-center'}>
+         { addNewBtn }
+         { overridePresetBtn }
+        </div>
       </div>
     );
   }
@@ -124,20 +135,20 @@ export class ProgramConfig extends React.Component<Props> {
 
 interface PresetsProps {
   presets: string[];
+  selected: string | undefined | null;
   onSelect(preset: string): void;
 }
 
-const Presets: React.FC<PresetsProps> = ({ presets, onSelect }) => {
+const Presets: React.FC<PresetsProps> = ({ presets, selected, onSelect }) => {
   if (presets.length === 0) {
     return null;
   }
 
   return (
     <div>
-      <hr />
       {presets.map(preset => (
         <button
-          className="btn btn-sm btn-outline-success mr-1 mb-1"
+          className={`btn btn-sm ${selected === preset ? 'btn-info' : 'btn-outline-info'} mr-1 mb-1`}
           key={preset}
           onClick={e => onSelect(preset)}
         >

--- a/web/src/StringParam.tsx
+++ b/web/src/StringParam.tsx
@@ -5,13 +5,13 @@ interface Props {
   name: string;
   value: string;
   options: string[];
-  onChange(e: React.SyntheticEvent, name: string, value: string): void;
+  onChange(name: string, value: string): void;
 }
 
 export class StringParam extends React.Component<Props> {
   handleChange = (event: React.SyntheticEvent, value: string) => {
     event.preventDefault();
-    this.props.onChange(event, this.props.name, value);
+    this.props.onChange(this.props.name, value);
   };
 
   render() {

--- a/web/src/SubprogramParam.tsx
+++ b/web/src/SubprogramParam.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import _ from "lodash";
+import { ConfigValue } from "./types";
+import { ProgramConfig } from "./ProgramConfig";
+
+interface Props {
+  name: string;
+  value: any;
+  options: any;
+  globalConfig: { [param: string]: any };
+  onChange(name: string, value: ConfigValue): void;
+}
+
+export class SubprogramParam extends React.Component<Props,any> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {
+      collapsed: true
+    }
+  }
+  handleChange(newConfig: { [name: string]: ConfigValue }) {
+    const { programName, presetName, config } = this.props.value;
+    this.props.onChange(this.props.name, { programName, config: { ...config, presetName, ...newConfig } });
+  }
+
+  handleProgramChange(programName: string) {
+    this.props.onChange(this.props.name, { programName });
+  }
+
+  handleSelectPreset(presetName: string) {
+    const { programName } = this.props.value;
+    // Setting a preset discards previous config
+    this.props.onChange(this.props.name, { programName, presetName, config: {} });
+  }
+
+  handleSavePreset(programName: string, presetName: string, presetConfig: { [param: string]: ConfigValue }) {
+
+  }
+
+  render() {
+    const { name, value, options, globalConfig } = this.props;
+
+    const { programName, presetName } = value || {};
+
+    const currentProgram = options[programName]
+
+    let programConfig = null;
+
+    let currentConfig = {
+      defaults: _.mapValues(currentProgram.config, 'default'),
+      overrides: value.config,
+      currentPreset: presetName
+    }
+
+    if(value) {
+      if(!this.state.collapsed) {
+        programConfig = <div className={'p-2 my-1 bg-lighter rounded'} style={{ zoom: '0.9' }}>
+          <span onClick={() => this.setState({collapsed: true})} className={'btn btn-sm btn-link mb-2'}>➖ Parameters {name}</span>
+
+          <ProgramConfig
+            program={currentProgram}
+            programs={options}
+            config={currentConfig}
+            globalConfig={globalConfig}
+            onSelectPreset={this.handleSelectPreset.bind(this)}
+            onSaveNewPreset={this.handleSavePreset.bind(this)}
+            onChangeProgramConfig={this.handleChange.bind(this)}/>
+        </div>
+      } else {
+        programConfig =
+          <div className={'p-0 my-1 bg-lighter rounded'} style={{ zoom: '0.9' }}>
+            <span onClick={() => this.setState({collapsed: false})} className={'btn btn-sm btn-link'}>➕ Parameters {name}</span>
+          </div>
+      }
+    }
+
+    return (
+      <div className="config-item">
+        <div className="">
+          <div className="float-left">
+            {name}&nbsp;
+          </div>
+
+          <div className="float-right font-weight-bold">
+            <div className="dropdown">
+              <button className="btn btn-sm btn-dark dropdown-toggle" type="button" id="dropdownMenuButton"
+                      data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                {programName}
+              </button>
+              <div className="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                {_.map(_.keys(options), (programId) => (
+                  <button
+                    key={programId}
+                    className={`small dropdown-item ${programId === programName ? "active" : ""}`}
+                    onClick={e => this.handleProgramChange(programId)}
+                  >{programId}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className={'clearfix'}></div>
+        {programConfig}
+      </div>
+    );
+  }
+}

--- a/web/src/TopProgramConfig.tsx
+++ b/web/src/TopProgramConfig.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Program, ConfigValue, CurrentProgramParameters } from "./types";
+import { ProgramConfig } from "./ProgramConfig";
+
+interface Props {
+  program: Program | null;
+  programs: any;
+  selected: string | null;
+  config: CurrentProgramParameters;
+  globalConfig: { [param: string]: any };
+  onSelectPreset(name: string): void;
+  onSaveNewPreset(programName: string, presetName: string, presetConfig: { [param: string]: ConfigValue }): void;
+  onRestartProgram(): void;
+  onChangeProgramConfig(config: { [name: string]: ConfigValue }): void;
+}
+
+export class TopProgramConfig extends React.PureComponent<Props> {
+  handleRestartProgram(e: React.SyntheticEvent) {
+    e.preventDefault();
+    this.props.onRestartProgram();
+  }
+
+  handleParamChange = (value: { [param: string]: ConfigValue }) => {
+    this.props.onChangeProgramConfig(value);
+  };
+
+  render() {
+    const currentProgram = this.props.program;
+    const currentParameters = this.props.config;
+
+    if (!currentProgram || !currentParameters.defaults) {
+      return null;
+    }
+
+    return (
+      <div>
+        <h5 className="">
+          {currentProgram.name} &nbsp;
+          <button
+            className="btn btn-sm btn-outline-secondary"
+            onClick={this.handleRestartProgram.bind(this)}
+          >
+            Restart
+          </button>
+        </h5>
+
+        <hr />
+      <ProgramConfig
+        program={currentProgram}
+        programs={this.props.programs}
+        config={currentParameters}
+        globalConfig={this.props.globalConfig}
+        onSelectPreset={this.props.onSelectPreset}
+        onSaveNewPreset={this.props.onSaveNewPreset}
+        onChangeProgramConfig={this.handleParamChange}/>
+      </div>
+    );
+  }
+}

--- a/web/src/api.tsx
+++ b/web/src/api.tsx
@@ -35,6 +35,10 @@ export class API extends EventEmitter {
     this.send("setPreset", preset);
   }
 
+  savePreset(programName: string, presetName: string, currentConfig: { [param: string]: ConfigValue }) {
+    this.send("savePreset", {programName, presetName, currentConfig});
+  }
+
   restartProgram() {
     this.send("restartProgram");
   }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -37,10 +37,23 @@ body {
   width: 100px;
 }
 
+.dropdown-menu {
+  max-height: 500px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 .gradient-dropdown {
   max-height: 300px;
   overflow-y: auto;
   overflow-x: hidden;
+}
+
+.bg-lighter {
+  background: rgba(255, 255, 255, 0.05);
+}
+.bg-lighter-info {
+  background: rgba(23, 162, 184, 0.11);
 }
 
 .devicesbar {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -9,7 +9,14 @@ export type ConfigDefinition =
   | { type: string, default: boolean }
   | { type: string, default: number; min: number; max: number; step: number };
 
-export type ConfigValue = string | number | boolean;
+export type ConfigValue = any;
+
+export type CurrentProgramParameters = {
+  defaults?: { [param: string]: ConfigValue },
+  presetOverrides?: { [param: string]: ConfigValue },
+  overrides?: { [param: string]: ConfigValue }
+  currentPreset?: string | null
+}
 
 export interface Device {
   deviceId: string;


### PR DESCRIPTION
Work in progress with several changes:

- Transform controller's currentProgram's currentConfig from { ... } to {defaults: {}, presetOverrides: {}, overrides: {}, currentPreset }.
- Update UI to show when a parameter has the program's default value, a preset's value or a custom override (from playing in the UI).
- Add a "save preset" button that saves presets in a defaults.json file (that later could be configurable / importable)
- Add new type of parameter "program", which consists of a program name and optional config overrides. 
- Refactor parameter's UI in a reusable component that can be used recursively. Added new subprogram component that uses it to show a nested ui to change parameters of subrpograms.
- Added a new "mix" program to showcase and test a first simple use of "program" parameters.

Had to add a couple of ugly new dependencies around,  but I think It could be a reasonable MVP for the gained functionality: now it should be almost straightforward to be able to combine several  programs and explore configurations that can be saved with a click in the UI, allowing non-coders to build new mash-ups of programs. If we are happy with how "programs" parameters work, we can move on to provide a more general UI for layers.