### PR TITLE
Generate fake audio params on silence.

### DIFF
--- a/audio/input.js
+++ b/audio/input.js
@@ -15,6 +15,7 @@ class AudioInput extends EventEmitter {
     // this._sampleRate = options._sampleRate || 48000;
     const deviceIndex = options.deviceIndex || null;
     const profile = options.profile || null;
+    const fakeAudio = !!options.fakeAudio;
     this._args = [ '-u' ];
     if (!profile) {
       this._args.push(mainScript);
@@ -24,6 +25,9 @@ class AudioInput extends EventEmitter {
     }
     if (deviceIndex) {
       this._args.push('-d', deviceIndex.toString());
+    }
+    if (fakeAudio) {
+      this._args.push('-f');
     }
     this._subprocess = null;
     this._stopping = false;

--- a/audio/main.py
+++ b/audio/main.py
@@ -68,8 +68,9 @@ def write_output_frame(frame):
     sys.stdout.buffer.flush()
 
 
-def audio_loop(device=None, sample_rate=48000, frame_size=512):
-    processor = RawAudioProcessor(sample_rate)
+def audio_loop(device=None, sample_rate=48000, frame_size=512, fake_audio=False):
+    logger.info('Fake audio: %s.', fake_audio)
+    processor = RawAudioProcessor(sample_rate=sample_rate, fake_audio=fake_audio)
     with sd.InputStream(device=device,
                         samplerate=sample_rate,
                         blocksize=frame_size,
@@ -91,6 +92,10 @@ def main():
                         type=int,
                         help='Index of the input device',
                         default=None)
+    parser.add_argument('-f',
+                        '--fake_audio',
+                        action='store_true',
+                        help='Enable fake audio values generation')
     parser.add_argument('-l',
                         '--list_devices',
                         action='store_true',
@@ -105,7 +110,7 @@ def main():
         device = sd.query_devices(args.device)
     logger.info('Using device "%s".', device['name'])
     try:
-        audio_loop(args.device)
+        audio_loop(device=args.device, fake_audio=args.fake_audio)
     except (KeyboardInterrupt, BrokenPipeError):
         pass
 

--- a/audio/playground.js
+++ b/audio/playground.js
@@ -10,6 +10,7 @@ const io = SocketIO(server);
 
 const audio = new AudioInput({
   // profile : true,
+  fakeAudio: true,
 });
 console.log('Audio devices:\n', listDevices());
 audio.start();

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -15,6 +15,7 @@ controller.start();
 console.log('Available audio devices:\n', listDevices());
 const audioInput = new AudioInput({
   deviceIndex: null,  // TODO: allow overriding device.
+  fakeAudio: true,
 });
 audioInput.on('audioframe', audioEmitter.updateFrame.bind(audioEmitter));
 audioInput.start();


### PR DESCRIPTION
Attempting to address #30.
If the input falls below a certain threshold, the audio capture process starts producing fake values. Works fine with perfect silence on my local loopback device, might want to play around a little bit over there with the actual hardware there to see if this is enough.