### PR TITLE
Adjust audio normalization to adapt faster.

### DIFF
--- a/audio/processor.py
+++ b/audio/processor.py
@@ -264,7 +264,9 @@ class RawAudioProcessor:
                 {
                     'fast': (0.06, ),
                     'mid': (0.02, ),
-                    'slow': (0.00005, ),
+                    # Slow alpha below controls global normalization.
+                    # Larger value => faster adaptation.
+                    'slow': (0.0002, ),
                 }, ['rms']),
             MovingStats({
                 'slow': (0.2, ),

--- a/audio/static/main.js
+++ b/audio/static/main.js
@@ -218,6 +218,9 @@
     renderers.push(new HistoryRenderer(addVizCanvas('rms', 600, 100),
                                        (frame) => { return frame.rms; }, 300));
     renderers.push(
+        new HistoryRenderer(addVizCanvas('max', 600, 100),
+                            (frame) => { return frame.max; }, 300));
+    renderers.push(
         new HistoryRenderer(addVizCanvas('bass', 600, 100),
                             (frame) => { return frame.bassFastPeakDecay; }, 300));
     renderers.push(


### PR DESCRIPTION
Older setting was way too slow, it would remember an old audio peak for
way too long.

Fixes #33.