### PR TITLE
Bugfixes for MultiProgram and noise

### DIFF
--- a/server/src/light-programs/base-programs/MultiPrograms.js
+++ b/server/src/light-programs/base-programs/MultiPrograms.js
@@ -6,6 +6,20 @@ function clamp(v, min, max) {
   return Math.max(min, Math.min(max, v));
 }
 
+function extractDefault(program) {
+  if (!program || !program.configSchema) {
+    return {};
+  }
+  let configSchema = program.configSchema();
+  let config = {};
+  for (let paramName in configSchema) {
+    if (configSchema[paramName].default !== undefined) {
+      config[paramName] = configSchema[paramName].default;
+    }
+  }
+  return config;
+}
+
 module.exports = function createMultiProgram(
   programSchedule,
   random = false,
@@ -23,7 +37,7 @@ module.exports = function createMultiProgram(
       // instantiate each program
       _.each(this.programSchedule, scheduleItem => {
           return (scheduleItem.programInstance = new scheduleItem.program(
-            this.config,
+            extractDefault(scheduleItem.program),
             this.geometry,
             this.shapeMapping,
             this.lightController

--- a/server/src/light-programs/programs/noise.js
+++ b/server/src/light-programs/programs/noise.js
@@ -32,22 +32,29 @@ module.exports = class Noise extends LightProgram {
       ? loadGradient(this.config.colorMap)
       : this.timedMultiGradient;
 
-    const noise = this.noise;
     const { x, y } = this.geometry;
     const t = this.time / 1000;
 
     var colors = new Array(this.numberOfLeds);
     for (let i = 0; i < colors.length; i++) {
       const v = rescale(
-        this.config.colorScale * noise.gen(x[i] / 32 + t, y[i] / 32 + t)
+        this.config.colorScale * this.gen(x[i] / 32 + t, y[i] / 32 + t)
       );
       const brightness = rescale(
         this.config.brightnessScale *
-          noise.gen(x[i] / 32 + t + 100, y[i] / 32 + t)
+          this.gen(x[i] / 32 + t + 100, y[i] / 32 + t)
       );
       colors[i] = gradient.colorAt(v).map(x => Math.floor(x * brightness));
     }
     draw(colors);
+  }
+
+  gen(x, y) {
+    try {
+      return this.noise.gen(x, y);
+    } catch {
+      return 0;
+    }
   }
 
   updateConfig(config) {


### PR DESCRIPTION
MultiProgram was passing the wrong config object to raw programs. Using extractDefaults to pass the right values.

Noise can sometime crash because an internal error in the noise library. Catch this and return 0.