### PR TITLE
Cleanup drawframe

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
   "author": "Pampa Warro",
   "license": "MIT",
   "dependencies": {
+    "accurate-game-loop": "^2.0.0",
     "cellular-automata": "^2.0.1",
     "cli-table2": "^0.2.0",
     "color-string": "^1.5.3",
@@ -23,7 +24,6 @@
     "dgram": "^1.0.1",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
-    "nanotimer": "^0.3.15",
     "node-fetch": "^2.6.6",
     "performance-now": "^2.1.0",
     "pino": "^5.15.0",

--- a/server/src/DeviceMultiplexer.js
+++ b/server/src/DeviceMultiplexer.js
@@ -85,6 +85,9 @@ module.exports = class DeviceMultiplexer {
       this.targetPosition[i] = position;
     }
 
+    this.deviceStateArrays = this.devices.map(
+        device => _.map(_.range(device.numberOfLights), i => [0, 0, 0]));
+
     this.statusCbk = () => null;
 
     // Report devices' states every 1s
@@ -108,19 +111,16 @@ module.exports = class DeviceMultiplexer {
   }
 
   setLights(rgbArray) {
-    const deviceStateArrays = this.devices.map(
-        device => _.map(_.range(device.numberOfLights), i => [0, 0, 0]));
-
     for (let i = 0; i < rgbArray.length; i++) {
       const deviceIndex = this.targetDevice[i];
       const positionIndex = this.targetPosition[i];
       if (deviceIndex >= 0) {
-        deviceStateArrays[deviceIndex][positionIndex] = rgbArray[i];
+        this.deviceStateArrays[deviceIndex][positionIndex] = rgbArray[i];
       }
     }
 
     for (let i = 0; i < this.devices.length; i++) {
-      this.devices[i].setLights(deviceStateArrays[i]);
+      this.devices[i].setLights(this.deviceStateArrays[i]);
     }
   }
 };

--- a/server/src/LightController.js
+++ b/server/src/LightController.js
@@ -128,10 +128,7 @@ module.exports = class LightController extends EventEmitter {
   start() {
     if (this.programScheduler) {
       this.currentConfig = this.buildParameters(this.programs[this.currentProgramName].configSchema);
-      this.programScheduler.start(
-        this.getConfig(this.currentConfig),
-        leds => this.updateLeds(leds)
-      );
+      this.programScheduler.start();
       this.running = true;
     }
   }
@@ -246,7 +243,9 @@ module.exports = class LightController extends EventEmitter {
         this.geometry,
         this.shapeMapping,
         this
-      )
+      ),
+      config,
+      this.updateLeds.bind(this)
     );
     if (this.running) {
       this.start();

--- a/server/src/LightController.js
+++ b/server/src/LightController.js
@@ -91,7 +91,7 @@ module.exports = class LightController extends EventEmitter {
   }
 
   getCurrentConfig() {
-    if (this.currentProgram) {
+    if (this.programScheduler) {
       return this.currentConfig
     } else {
       return {}
@@ -118,7 +118,7 @@ module.exports = class LightController extends EventEmitter {
   }
 
   getCurrentPresets() {
-    if (this.currentProgram) {
+    if (this.programScheduler) {
       return this.getProgramPresets(this.currentProgramName);
     } else {
       return {};
@@ -126,9 +126,9 @@ module.exports = class LightController extends EventEmitter {
   }
 
   start() {
-    if (this.currentProgram) {
+    if (this.programScheduler) {
       this.currentConfig = this.buildParameters(this.programs[this.currentProgramName].configSchema);
-      this.currentProgram.start(
+      this.programScheduler.start(
         this.getConfig(this.currentConfig),
         leds => this.updateLeds(leds)
       );
@@ -137,13 +137,13 @@ module.exports = class LightController extends EventEmitter {
   }
 
   restart() {
-    this.currentProgram.restart();
+    this.programScheduler.restart();
   }
 
   stop() {
     this.running = false;
-    if (this.currentProgram) {
-      this.currentProgram.stop();
+    if (this.programScheduler) {
+      this.programScheduler.stop();
     }
   }
 
@@ -170,7 +170,7 @@ module.exports = class LightController extends EventEmitter {
     let configSchema = this.programs[this.currentProgramName].configSchema;
     let { presetOverrides, currentPreset, overrides } = this.currentConfig;
     this.currentConfig = this.buildParameters(configSchema, presetOverrides, currentPreset, {... overrides, ... config})
-    this.currentProgram.updateConfig(this.getConfig(this.currentConfig));
+    this.programScheduler.updateConfig(this.getConfig(this.currentConfig));
   }
 
   setPreset(presetName) {
@@ -185,7 +185,7 @@ module.exports = class LightController extends EventEmitter {
     let configSchema = this.programs[this.currentProgramName].configSchema;
 
     this.currentConfig = this.buildParameters(configSchema, presetOverrides, presetName, {})
-    this.currentProgram.updateConfig(this.getConfig(this.currentConfig));
+    this.programScheduler.updateConfig(this.getConfig(this.currentConfig));
   }
 
   savePreset(programName, presetName, config) {
@@ -231,8 +231,8 @@ module.exports = class LightController extends EventEmitter {
       return;
     }
 
-    if (this.running && this.currentProgram) {
-      this.currentProgram.stop();
+    if (this.running && this.programScheduler) {
+      this.programScheduler.stop();
     }
     this.currentProgramName = name;
     let program = this.programs[name];
@@ -240,7 +240,7 @@ module.exports = class LightController extends EventEmitter {
     this.currentConfig = this.buildParameters(program.configSchema)
     let config = this.getConfig(this.currentConfig);
 
-    this.currentProgram = new ProgramScheduler(
+    this.programScheduler = new ProgramScheduler(
       new program.generator(
         config,
         this.geometry,

--- a/server/src/LightController.js
+++ b/server/src/LightController.js
@@ -69,7 +69,7 @@ module.exports = class LightController extends EventEmitter {
     this.geometry = geometry;
     this.shapeMapping = shapeMapping;
 
-    this.leds = [];
+    this.leds = new Array(geometry.leds).fill([0, 0, 0]);
 
     this.programs = _.keyBy(_.map(programNames, this.loadProgram), "name");
     this.setCurrentProgram(programNames[0]);
@@ -245,6 +245,7 @@ module.exports = class LightController extends EventEmitter {
         this
       ),
       config,
+      this.leds,
       this.updateLeds.bind(this)
     );
     if (this.running) {
@@ -261,12 +262,12 @@ module.exports = class LightController extends EventEmitter {
     };
   }
 
-  updateLeds(rgbaLeds) {
+  updateLeds(leds) {
     // TODO: remove rgba before?
-    const rgbLeds = _.map(rgbaLeds, rgba => rgba.slice(0, 3));
-    this.emit("lights", rgbLeds);
+    leds.forEach(color => color.length = 3);
+    this.emit("lights", leds);
 
-    this.setLights(rgbLeds);
+    this.setLights(leds);
     let lastUpdateLatency = Date.now() - this.lastLightsUpdate;
     this.lastLightsUpdate = Date.now();
     // TODO: where does the number 34 come from?

--- a/server/src/LightController.js
+++ b/server/src/LightController.js
@@ -263,8 +263,6 @@ module.exports = class LightController extends EventEmitter {
   }
 
   updateLeds(leds) {
-    // TODO: remove rgba before?
-    leds.forEach(color => color.length = 3);
     this.emit("lights", leds);
 
     this.setLights(leds);

--- a/server/src/LightsService.js
+++ b/server/src/LightsService.js
@@ -4,8 +4,18 @@ const audioEmitter = require("./audioEmitter");
 const {getGradientsByNameCss} = require('./light-programs/utils/gradients')
 
 function lightsToByteString(ledsColorArray) {
-  let bytes = _.flatten(ledsColorArray);
-  return Buffer.from(bytes).toString("base64");
+  // Note: this function is in a hot code path. If you're tempted to change this
+  // (e.g. simplify using _.flatten), run some profiling to make sure there
+  // isn't a CPU time or memory allocation regression.
+  const buffer = Buffer.allocUnsafe(ledsColorArray.length * 3);
+  for (let i = 0; i < ledsColorArray.length; i++) {
+    const offset = i * 3;
+    const led = ledsColorArray[i];
+    buffer[offset] = led[0];
+    buffer[offset + 1] = led[1];
+    buffer[offset + 2] = led[2];
+  }
+  return buffer.toString("base64");
 }
 
 let lightServicesCounter = 0;

--- a/server/src/ProgramScheduler.js
+++ b/server/src/ProgramScheduler.js
@@ -49,9 +49,11 @@ module.exports = class ProgramScheduler {
       }
 
       lastFlushTime = now;
-      this.leds.forEach((col, i) => {
-        this.leds[i] = ColorUtils.dim(col, this.config.globalBrightness);
-      });
+      if (this.config.globalBrightness != 1) {
+        this.leds.forEach((col, i) => {
+          this.leds[i] = ColorUtils.dim(col, this.config.globalBrightness);
+        });
+      }
       this.ledsUpdatedCallback(this.leds);
     };
     this.loop = new Loop(frame, this.config.fps);

--- a/server/src/ProgramScheduler.js
+++ b/server/src/ProgramScheduler.js
@@ -8,18 +8,18 @@ const NanoTimer = require('nanotimer');
 
 module.exports = class ProgramScheduler {
 
-  constructor(program) {
+  constructor(program, config, newFrameCallback) {
     this.program = program;
+    this.config = config;
+    this.newFrameCallback = newFrameCallback;
     this.timeInMs = 0;
     this.startTime = null;
     this.nextTickTimeout = null;
   }
 
-  start(config, draw) {
+  start() {
     this.timeInMs = 0;
     this.startTime = Date.now();
-    this.config = config;
-    this.draw = draw;
     this.timer = new NanoTimer();
 
     this.program.init();
@@ -52,7 +52,7 @@ module.exports = class ProgramScheduler {
 
           clearInterval(this.nextTickTimeout);
           lastFlushTime = now;
-          draw(_.map(colorsArray, col => ColorUtils.dim(col, this.config.globalBrightness)));
+          this.newFrameCallback(_.map(colorsArray, col => ColorUtils.dim(col, this.config.globalBrightness)));
 
           frame();
         }, '', remainingTime + 'm');
@@ -71,7 +71,7 @@ module.exports = class ProgramScheduler {
   restart() {
     this.stop();
     this.program.init();
-    this.start(this.config, this.draw);
+    this.start();
   }
 
   get config() {

--- a/server/src/devices/base.js
+++ b/server/src/devices/base.js
@@ -12,7 +12,7 @@ const { DEBUG, INFO, WARNING, ERROR } = {
 
 exports.LightDevice = class LightDevice {
   constructor(numberOfLights, deviceId) {
-    this.state = _.range(0, numberOfLights);
+    this.state = new Array(numberOfLights).fill([0, 0, 0]);
     this.numberOfLights = numberOfLights;
 
     this.deviceId = deviceId;
@@ -56,8 +56,6 @@ exports.LightDevice = class LightDevice {
   }
 
   setLights(rgbArray) {
-    // Initialize everything black
-    this.state.fill([0, 0, 0]);
     for (let i = 0; i < this.numberOfLights; i++) {
       this.state[i] = rgbArray[i % rgbArray.length];
     }

--- a/server/src/devices/base.js
+++ b/server/src/devices/base.js
@@ -57,12 +57,10 @@ exports.LightDevice = class LightDevice {
 
   setLights(rgbArray) {
     // Initialize everything black
-    const newState = _.map(_.range(this.numberOfLights), () => [0, 0, 0]);
-
+    this.state.fill([0, 0, 0]);
     for (let i = 0; i < this.numberOfLights; i++) {
-      newState[i] = rgbArray[i % rgbArray.length];
+      this.state[i] = rgbArray[i % rgbArray.length];
     }
-    this.state = newState;
     this.freshData = true;
     this.sendNextFrame();
   }

--- a/server/src/hackProgramReloadOnRestart.js
+++ b/server/src/hackProgramReloadOnRestart.js
@@ -26,6 +26,7 @@ module.exports = function hackLightControllerRestart(controller) {
           this
         ),
         config,
+        this.leds,
         this.updateLeds.bind(this)
       );
 

--- a/server/src/hackProgramReloadOnRestart.js
+++ b/server/src/hackProgramReloadOnRestart.js
@@ -5,8 +5,8 @@ module.exports = function hackLightControllerRestart(controller) {
     try {
       const name = this.currentProgramName;
 
-      if (this.running && this.currentProgram) {
-        this.currentProgram.stop();
+      if (this.running && this.programScheduler) {
+        this.programScheduler.stop();
       }
 
       _.each(require.cache, (v, key) => {
@@ -18,7 +18,7 @@ module.exports = function hackLightControllerRestart(controller) {
       this.programs = _.keyBy(_.map(Object.keys(this.programs), this.loadProgram), "name");
 
       let config = this.getConfig(this.currentConfig);
-      this.currentProgram = new ProgramScheduler(
+      this.programScheduler = new ProgramScheduler(
         new this.programs[name].generator(
           config,
           this.geometry,
@@ -27,7 +27,7 @@ module.exports = function hackLightControllerRestart(controller) {
         )
       );
 
-      this.currentProgram.start(
+      this.programScheduler.start(
         this.getConfig(this.currentConfig),
         leds => this.updateLeds(leds)
       );

--- a/server/src/hackProgramReloadOnRestart.js
+++ b/server/src/hackProgramReloadOnRestart.js
@@ -24,13 +24,12 @@ module.exports = function hackLightControllerRestart(controller) {
           this.geometry,
           this.shapeMapping,
           this
-        )
+        ),
+        config,
+        this.updateLeds.bind(this)
       );
 
-      this.programScheduler.start(
-        this.getConfig(this.currentConfig),
-        leds => this.updateLeds(leds)
-      );
+      this.programScheduler.start();
     } catch(err) {
       console.log(err);
     }

--- a/server/src/light-programs/base-programs/AnimatePrograms.js
+++ b/server/src/light-programs/base-programs/AnimatePrograms.js
@@ -5,12 +5,12 @@ module.exports = function animateParamProgram(
   change
 ) {
   return class AnimateParam extends Program {
-    drawFrame(draw, audio) {
+    drawFrame(leds, context) {
       this.count = (this.count || 0) + 1;
       if (this.count % frequency == 0) {
         this.config[parameter] = change.apply(this, [this.config[parameter]]);
       }
-      super.drawFrame(draw, audio);
+      super.drawFrame(leds, context);
     }
   };
 };

--- a/server/src/light-programs/base-programs/FX.js
+++ b/server/src/light-programs/base-programs/FX.js
@@ -12,13 +12,10 @@ function makeBaseFXProgram(WrappedProgram) {
 
     init() { return this.wrapped.init(); }
 
-    drawFrame(draw, audio) {
-      let frame = null;
+    drawFrame(leds, context) {
       this.wrapped.timeInMs = this.timeInMs;
-      this.wrapped.drawFrame(colors => {
-        this.processFrame(colors, audio);
-        draw(colors);
-      }, audio);
+      this.wrapped.drawFrame(leds, context);
+      this.processFrame(leds, context);
     }
 
     updateConfig(config) {
@@ -42,7 +39,7 @@ function makeDelay(WrappedProgram) {
       this.pastFrames = [];
     }
 
-    processFrame(frame, audio) {
+    processFrame(leds, context) {
       let ms = this.config.FXDelayMs;
       let dry = this.config.FXDelayDry;
       let wet = this.config.FXDelayWet;
@@ -51,7 +48,7 @@ function makeDelay(WrappedProgram) {
       }
       let feedback = this.config.FXDelayFeedback;
 
-      let savedFrame = _.clone(frame);
+      let savedFrame = _.clone(leds);
       this.pastFrames.push([ this.timeInMs, savedFrame ]);
 
       let pastFrame = null;
@@ -68,15 +65,15 @@ function makeDelay(WrappedProgram) {
       if (!pastFrame) {
         return;
       }
-      for (let i = 0; i < frame.length; i++) {
-        let currentColor = _.map(frame[i], x => x * dry);
+      for (let i = 0; i < leds.length; i++) {
+        let currentColor = _.map(leds[i], x => x * dry);
         let pastColor = _.map(pastFrame[i], x => x * wet);
-        frame[i] = ColorUtils.max(currentColor, pastColor);
+        leds[i] = ColorUtils.max(currentColor, pastColor);
       }
 
       if (feedback > 0) {
-        for (let i = 0; i < frame.length; i++) {
-          savedFrame[i] = ColorUtils.mix(savedFrame[i], frame[i], feedback);
+        for (let i = 0; i < leds.length; i++) {
+          savedFrame[i] = ColorUtils.mix(savedFrame[i], leds[i], feedback);
         }
       }
     }
@@ -104,20 +101,20 @@ function makeSlowFade(WrappedProgram) {
       this.lastFrame = null;
     }
 
-    processFrame(frame, audio) {
+    processFrame(leds, context) {
       let alpha = this.config.FXSlowFadeAlpha;
       if(alpha > 0) {
         if (this.lastFrame) {
-          for (let i = 0; i < frame.length; i++) {
+          for (let i = 0; i < leds.length; i++) {
             let oldColor = this.lastFrame[i];
-            let color = frame[i];
+            let color = leds[i];
             if (Math.max(...color) < Math.max(...oldColor)) {
               // Less bright, slow fade.
-              frame[i] = ColorUtils.mix(color, oldColor, alpha);
+              leds[i] = ColorUtils.mix(color, oldColor, alpha);
             }
           }
         }
-        this.lastFrame = frame;
+        this.lastFrame = leds;
       }
     }
 

--- a/server/src/light-programs/base-programs/LayerBasedProgram.js
+++ b/server/src/light-programs/base-programs/LayerBasedProgram.js
@@ -72,17 +72,16 @@ module.exports = class LayerBasedProgram extends LightProgram {
     console.warn("Unimplemented updateState()");
   }
 
-  drawFrame(draw, audio) {
-    this.updateState(audio);
-    const colors = new Array(this.numberOfLeds);
-    colors.fill([0, 0, 0, 1]);
+  drawFrame(leds, context) {
+    this.updateState(context.audio);
+    leds.fill([0, 0, 0, 1]);
     if (!this.rootLayer) {
       console.error("Missing rootLayer.");
     }
-    colors.forEach((baseColor, i) => {
+    leds.forEach((baseColor, i) => {
       const color = this.rootLayer.applyAtIndex(i, this.geometry, baseColor);
-      colors[i] = color.splice(0, 3);
+      color.length = 3;
+      leds[i] = color;
     });
-    draw(colors);
   }
 };

--- a/server/src/light-programs/base-programs/LightProgram.js
+++ b/server/src/light-programs/base-programs/LightProgram.js
@@ -10,7 +10,7 @@ module.exports = class LightProgram {
   init() {}
 
   // Override in subclasses
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
     throw new Error("Child classes should override drawFrame");
   }
 

--- a/server/src/light-programs/base-programs/MixProgram.js
+++ b/server/src/light-programs/base-programs/MixProgram.js
@@ -47,6 +47,7 @@ module.exports = function mixPrograms(...programs) {
         // TODO: remove this forwarding somehow
         p.programInstance.timeInMs = this.timeInMs;
 
+        p.leds.fill([0, 0, 0]);
         p.programInstance.drawFrame(p.leds, context);
         frames.push(p.leds);
       });

--- a/server/src/light-programs/base-programs/MultiPrograms.js
+++ b/server/src/light-programs/base-programs/MultiPrograms.js
@@ -76,7 +76,9 @@ module.exports = function createMultiProgram(
         this.previous.timeInMs = this.timeInMs;
         this.current.timeInMs = this.timeInMs;
 
+        previousColors.fill([0, 0, 0]);
         this.previous.drawFrame(previousColors, context);
+        currentColors.fill([0, 0, 0]);
         this.current.drawFrame(currentColors, context);
 
         let alpha = clamp(

--- a/server/src/light-programs/programs/aliveDots.js
+++ b/server/src/light-programs/programs/aliveDots.js
@@ -26,13 +26,14 @@ module.exports = class AliveDots extends LightProgram {
     );
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
     // let decay = this.config.decay;
+    const audio = context.audio;
     if (!audio.ready) {
       return;
     }
     this.time++;
-    this.stars = [...Array(this.numberOfLeds)].map(() => [0, 0, 0]);
+    leds.fill([0, 0, 0]);
 
     _.each(this.dots, dot => {
       let roundPos = Math.floor(dot.pos);
@@ -43,8 +44,8 @@ module.exports = class AliveDots extends LightProgram {
         dot.val
       );
 
-      let [r, g, b] = this.stars[roundPos];
-      let [ru, gu, bu] = this.stars[roundPosNext];
+      let [r, g, b] = leds[roundPos];
+      let [ru, gu, bu] = leds[roundPosNext];
 
       this.updateDot(dot, audio);
 
@@ -58,16 +59,14 @@ module.exports = class AliveDots extends LightProgram {
         bu + high * b2
       );
 
-      this.stars[roundPos] = [r, g, b];
-      this.stars[roundPosNext] = [ru, gu, bu];
+      leds[roundPos] = [r, g, b];
+      leds[roundPosNext] = [ru, gu, bu];
     });
 
     this.lastVolume = audio.currentFrame[this.config.soundMetric] || 0;
-    draw(
-      this.stars.map(([r, g, b]) =>
-        ColorUtils.dim([r, g, b], this.config.brillo)
-      )
-    );
+    leds.forEach(([r, g, b], i) => {
+      leds[i] = ColorUtils.dim([r, g, b], this.config.brillo)
+    });
   }
 
   updateDot(dot, audio) {

--- a/server/src/light-programs/programs/aliveDotsSpeed.js
+++ b/server/src/light-programs/programs/aliveDotsSpeed.js
@@ -40,13 +40,14 @@ module.exports = class AliveDotsSpeed extends LightProgram {
     }
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    const audio = context.audio;
     if (!audio.ready) {
       return;
     }
     // let decay = this.config.decay;
     this.time++;
-    this.stars = [...Array(this.numberOfLeds)].map(() => [0, 0, 0]);
+    leds.fill([0, 0, 0]);
 
     for (let dot of this.dots) {
       let roundPos = Math.floor(dot.pos);
@@ -57,8 +58,8 @@ module.exports = class AliveDotsSpeed extends LightProgram {
         dot.val
       );
 
-      let [r, g, b] = this.stars[roundPos];
-      let [ru, gu, bu] = this.stars[roundPosNext];
+      let [r, g, b] = leds[roundPos];
+      let [ru, gu, bu] = leds[roundPosNext];
 
       dot.update(this.config.speedWeight, audio.currentFrame.slowRms);
 
@@ -72,15 +73,13 @@ module.exports = class AliveDotsSpeed extends LightProgram {
         bu + high * b2
       );
 
-      this.stars[roundPos] = [r, g, b];
-      this.stars[roundPosNext] = [ru, gu, bu];
+      leds[roundPos] = [r, g, b];
+      leds[roundPosNext] = [ru, gu, bu];
     }
 
-    draw(
-      this.stars.map(([r, g, b]) =>
-        ColorUtils.dim([r, g, b], this.config.brillo)
-      )
-    );
+    leds.forEach(([r, g, b], i) => {
+      leds[i] = ColorUtils.dim([r, g, b], this.config.brillo)
+    });
   }
 
   static presets() {

--- a/server/src/light-programs/programs/all-off.js
+++ b/server/src/light-programs/programs/all-off.js
@@ -2,8 +2,7 @@ const LightProgram = require("./../base-programs/LightProgram");
 
 module.exports = class AllOff extends LightProgram {
   // Override base class
-  drawFrame(draw) {
-    let colors = new Array(this.numberOfLeds).fill([0, 0, 0]); // Array del tamaño de las luces
-    draw(colors);
+  drawFrame(leds, context) {
+    leds.fill([0, 0, 0]);
   }
 };

--- a/server/src/light-programs/programs/all-white.js
+++ b/server/src/light-programs/programs/all-white.js
@@ -3,12 +3,10 @@ const ColorUtils = require("./../utils/ColorUtils");
 
 module.exports = class AllWhite extends LightProgram {
   // Override base class
-  drawFrame(draw) {
+  drawFrame(leds, context) {
     // En HSV blanco es (0,0,1)
     let tonoDeBlanco = ColorUtils.HSVtoRGB(0, 0, this.config.brillo);
-
-    let colors = new Array(this.numberOfLeds).fill(tonoDeBlanco);
-    draw(colors);
+    leds.fill(tonoDeBlanco);
   }
 
   // Override and extend config Schema

--- a/server/src/light-programs/programs/ca.js
+++ b/server/src/light-programs/programs/ca.js
@@ -23,7 +23,8 @@ module.exports = class CA extends LightProgram {
     }
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    const audio = context.audio;
     const time = this.timeInMs / 1000;
     this.cellularAutomata.setRule(this.config.rule);
     if (
@@ -35,7 +36,6 @@ module.exports = class CA extends LightProgram {
       this.lastIterationTime = time;
     }
     this.timedMultiGradient.currentTime = time;
-    const colors = new Array(this.numberOfLeds);
     const blend = this.config.blend;
     const gradient = this.config.colorMap
       ? loadGradient(this.config.colorMap)
@@ -47,13 +47,12 @@ module.exports = class CA extends LightProgram {
       const value = this.cellularAutomata.array.get(i);
       this.values[i] = (1 - blend) * this.values[i] + blend * value;
     }
-    for (var i = 0; i < colors.length; i++) {
+    for (var i = 0; i < leds.length; i++) {
       const value = this.values[Math.floor(i / this.config.scale)];
       const brightness = Math.pow(value, 8);
       const [r, g, b, a] = gradient.colorAt(brightness);
-      colors[i] = [r * brightness, g * brightness, b * brightness];
+      leds[i] = [r * brightness, g * brightness, b * brightness];
     }
-    draw(colors);
   }
 
   static presets() {

--- a/server/src/light-programs/programs/circles.js
+++ b/server/src/light-programs/programs/circles.js
@@ -28,10 +28,8 @@ module.exports = class Circles extends LightProgram {
     this.yBounds = findBounds(geometry.y);
   }
 
-  drawFrame(draw, audio) {
-    const colors = new Array(this.numberOfLeds);
-
-    const frame = audio.currentFrame;
+  drawFrame(colors, context) {
+    const frame = context.audio.currentFrame;
     if (!frame) {
       return;
     }
@@ -68,8 +66,6 @@ module.exports = class Circles extends LightProgram {
       const color = ColorUtils.HSVtoRGB(h, s, v);
       colors[i] = color;
     }
-
-    draw(colors);
   }
 
   static presets() {

--- a/server/src/light-programs/programs/color-spear.js
+++ b/server/src/light-programs/programs/color-spear.js
@@ -7,23 +7,21 @@ module.exports = class ColorSpear extends LightProgram {
     this.time = 0;
   }
 
-  drawFrame(draw) {
+  drawFrame(leds) {
     this.time += this.config.speed;
     const punta = this.time;
-    const newColors = new Array(this.numberOfLeds);
 
     for (let i = 0; i < this.numberOfLeds; i++) {
-      newColors[i] = [0, 0, 0];
+      leds[i] = [0, 0, 0];
     }
     const colorTime = this.config.colorTime * 1000;
     for (let i = 0; i < this.config.spearLength; i++) {
-      newColors[(punta + i) % this.numberOfLeds] = ColorUtils.HSVtoRGB(
+      leds[(punta + i) % this.numberOfLeds] = ColorUtils.HSVtoRGB(
         ((this.time + i * this.config.colorVariety) % colorTime) / colorTime,
         1,
         this.config.brillo
       );
     }
-    draw(newColors);
   }
 
   static presets() {

--- a/server/src/light-programs/programs/congaRope.js
+++ b/server/src/light-programs/programs/congaRope.js
@@ -7,7 +7,6 @@ module.exports = class CongaShooting extends LightProgram {
   init() {
     this.center = this.numberOfLeds / 2;
     this.segmentSize = 60;
-    this.colors = new Array(this.numberOfLeds);
     this.rope = {pos: this.center - this.segmentSize, length: 2 * this.segmentSize};
     this.explosionLevel = 0;
     this.time = 0;
@@ -31,7 +30,7 @@ module.exports = class CongaShooting extends LightProgram {
       this.updateAudioWindow(audio);
       let burstSizeP1 = _.sum(this.audioWindow1);
       let burstSizeP2 = _.sum(this.audioWindow2);
-      console.log(burstSizeP1, burstSizeP2);
+      //console.log(burstSizeP1, burstSizeP2);
 
       if(burstSizeP1 < this.config.burstThreshold){
           burstSizeP1 = 0;
@@ -65,10 +64,10 @@ module.exports = class CongaShooting extends LightProgram {
           this.resetBurstsForPlayer(player);
       }
   }
-  paintAll(){
+  paintAll(leds){
       let baseColor = ColorUtils.HSVtoRGB(0, 0, this.explosionLevel/20);
       for (let i = 0; i < this.numberOfLeds; i++) {
-          this.colors[i] = [255,255,255];
+          leds[i] = [255,255,255];
       }
   }
 
@@ -80,12 +79,13 @@ module.exports = class CongaShooting extends LightProgram {
           this.audioWindow2.fill(0);
       }
   }
-  gameOver(winner){
+  gameOver(winner, leds){
       this.rope = {pos: this.center - this.segmentSize, length: 2 * this.segmentSize};
-      this.paintAll();
+      this.paintAll(leds);
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    let audio = context.audio;
     audio = audio.currentFrame || {};
     let bursts = this.detectBursts(audio);
     let burstP1 = bursts[0];
@@ -98,19 +98,18 @@ module.exports = class CongaShooting extends LightProgram {
     }
 
     if (this.rope.pos == 0){
-        this.gameOver('P1');
+        this.gameOver('P1', leds);
     }
     if(this.rope.pos + this.rope.length == this.numberOfLeds){
-        this.gameOver('P2');
+        this.gameOver('P2', leds);
     }
     let baseColor = ColorUtils.HSVtoRGB(0, 0, this.explosionLevel/20);
     for (let i = 0; i < this.numberOfLeds; i++) {
-        this.colors[i] = baseColor;
+        leds[i] = baseColor;
         if (i >= this.rope.pos && i < this.rope.pos+this.rope.length){
-            this.colors[i] = [255,255,0];
+            leds[i] = [255,255,0];
         }
     }
-    draw(this.colors);
   }
 
   static presets() {

--- a/server/src/light-programs/programs/congaScore.js
+++ b/server/src/light-programs/programs/congaScore.js
@@ -4,27 +4,26 @@ const _ = require("lodash");
 const GlobalGame = require('../conga-utils/GlobalGame');
 
 module.exports = class CongaShooting extends LightProgram {
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
     const player = this.config.playerNumber;
     const n = this.numberOfLeds;
     let max = GlobalGame.game.max();
     let m = n - (n % max);
     let score = GlobalGame.game.score[player] / max;
 
-    let colors = new Array(n).fill(null).map((v, i) => {
+    leds.forEach((v, i) => {
       if(this.config.reverse) {
         i = n-i+1;
       }
       if(i / n < score) {
-        return ColorUtils.HSVtoRGB(this.config.colorHue + player/2, this.config.colorSat, 1);
+        leds[i] = ColorUtils.HSVtoRGB(this.config.colorHue + player/2, this.config.colorSat, 1);
       } else {
         if(i % (m/max) === 0)
-          return [10,10,10];
+          leds[i] = [10,10,10];
         else
-          return [0,0,0];
+          leds[i] = [0,0,0];
       }
     })
-    draw(colors);
   }
 
   static presets() {

--- a/server/src/light-programs/programs/congaShooting.js
+++ b/server/src/light-programs/programs/congaShooting.js
@@ -5,7 +5,6 @@ const _ = require("lodash");
 module.exports = class CongaShooting extends LightProgram {
 
   init() {
-    this.colors = new Array(this.numberOfLeds);
     this.bulletsA = [];
     this.bulletsB = [];
     this.explosionLevel = 0;
@@ -47,7 +46,8 @@ module.exports = class CongaShooting extends LightProgram {
       }
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    let audio = context.audio;
     audio = audio.currentFrame || {};
     this.time += this.config.speed;
 
@@ -64,20 +64,18 @@ module.exports = class CongaShooting extends LightProgram {
     let baseColor = ColorUtils.HSVtoRGB(0, 0, this.explosionLevel/20);
     this.simulate();
     for (let i = 0; i < this.numberOfLeds; i++) {
-        this.colors[i] = baseColor;
+        leds[i] = baseColor;
         for(const b of this.bulletsA){
             if (b.pos == i){
-                this.colors[i] = [255,255,0];
+                leds[i] = [255,255,0];
             }
         }
         for(const b of this.bulletsB){
             if (b.pos == i){
-                this.colors[i] = [0, 255, 255];
+                leds[i] = [0, 255, 255];
             }
         }
     }
-
-    draw(this.colors);
   }
 
   static presets() {

--- a/server/src/light-programs/programs/congaShooting2.js
+++ b/server/src/light-programs/programs/congaShooting2.js
@@ -7,7 +7,6 @@ const {Glob} = require("glob");
 module.exports = class CongaShooting extends LightProgram {
 
   init() {
-    this.colors = new Array(this.numberOfLeds);
     this.bulletsA = [];
     this.bulletsB = [];
     this.explosionLevel = 0;
@@ -76,7 +75,8 @@ module.exports = class CongaShooting extends LightProgram {
       }
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    let audio = context.audio;
     audio = audio.currentFrame || {};
     this.frame ++;
     this.time += this.config.speed;
@@ -94,20 +94,18 @@ module.exports = class CongaShooting extends LightProgram {
     let baseColor = ColorUtils.HSVtoRGB(0, 0, this.explosionLevel/20);
     this.simulate();
     for (let i = 0; i < this.numberOfLeds; i++) {
-        this.colors[i] = baseColor;
+        leds[i] = baseColor;
         for(const b of this.bulletsA){
             if (Math.abs(b.pos - i) < this.config.speed){
-                this.colors[i] = ColorUtils.HSVtoRGB(b.size/400, 1, 1);
+                leds[i] = ColorUtils.HSVtoRGB(b.size/400, 1, 1);
             }
         }
         for(const b of this.bulletsB){
             if (Math.abs(b.pos - i) < this.config.speed){
-              this.colors[i] = ColorUtils.HSVtoRGB(b.size/400+0.33, 1, 1);
+              leds[i] = ColorUtils.HSVtoRGB(b.size/400+0.33, 1, 1);
             }
         }
     }
-
-    draw(this.colors);
   }
 
   static presets() {

--- a/server/src/light-programs/programs/debugSetup.js
+++ b/server/src/light-programs/programs/debugSetup.js
@@ -3,24 +3,20 @@ const ColorUtils = require("./../utils/ColorUtils");
 
 module.exports = class DebugSetup extends LightProgram {
   // Override base class
-  drawFrame(draw) {
-    let colors = [...Array(this.numberOfLeds)]; // Array del tamaño de las luces
+  drawFrame(leds) {
+    leds.forEach((v, i) => {
+      let s = 1
+      let scale = i > 1200 ? 150 : 300;
 
-    draw(
-      colors.map((v, i) => {
-        let s = 1
-        let scale = i > 1200 ? 150 : 300;
-
-        if(i % 10 === 0)
-          return [255,255,255,255];
-        else
-        return ColorUtils.HSVtoRGB(
-          (Math.floor(i / scale) / 4)+(i%scale)/(scale*4),
-          0.9 * s,
-          Math.min(1, this.config.brillo)
-        );
-      })
-    );
+      if(i % 10 === 0)
+        return [255,255,255,255];
+      else
+      leds[i] = ColorUtils.HSVtoRGB(
+        (Math.floor(i / scale) / 4)+(i%scale)/(scale*4),
+        0.9 * s,
+        Math.min(1, this.config.brillo)
+      );
+    });
   }
 
   // Override and extend config Schema

--- a/server/src/light-programs/programs/frequencyActivation.js
+++ b/server/src/light-programs/programs/frequencyActivation.js
@@ -4,13 +4,14 @@ const ColorUtils = require("./../utils/ColorUtils");
 module.exports = class FrequencyActivation extends LightProgram {
 
   init() {
-    this.lastVolume = new Array(this.numberOfLeds + 1).fill([0, 0, 0]);
+    this.lastVolume = new Array(this.numberOfLeds).fill([0, 0, 0]);
     this.time = 0;
     this.maxVolume = 0;
   }
 
   // Override parent method
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    const audio = context.audio;
     if (!audio.ready) {
       return;
     }
@@ -26,7 +27,9 @@ module.exports = class FrequencyActivation extends LightProgram {
       this.lastVolume[i] = newVal;
     }
 
-    draw(this.lastVolume);
+    this.lastVolume.forEach((v, i) => {
+      leds[i] = v;
+    });
   }
 
   static presets() {

--- a/server/src/light-programs/programs/lineal.js
+++ b/server/src/light-programs/programs/lineal.js
@@ -4,8 +4,7 @@ const ColorUtils = require("./../utils/ColorUtils");
 const {loadGradient} = require("../utils/gradients");
 
 module.exports = class Lineal extends LightProgram {
-  drawFrame(draw) {
-    const colors = new Array(this.numberOfLeds);
+  drawFrame(leds) {
     const elapsed = this.timeInMs / 1000;
 
     this.extraTime = (this.extraTime || 0) + Math.random() * 10;
@@ -28,13 +27,12 @@ module.exports = class Lineal extends LightProgram {
       const brightness = Math.pow(v, this.config.power);
       if (this.config.colorMap) {
         const gradient = loadGradient(this.config.colorMap);
-        colors[i] = gradient.colorAt(1-brightness);
+        leds[i] = gradient.colorAt(1-brightness);
       } else {
-        colors[i] = ColorUtils.HSVtoRGB((distance / 50 + this.extraTime / 1000) % 1, this.config.saturation, brightness);
+        leds[i] = ColorUtils.HSVtoRGB((distance / 50 + this.extraTime / 1000) % 1, this.config.saturation, brightness);
       }
 
     }
-    draw(colors);
   }
 
   static presets() {

--- a/server/src/light-programs/programs/musicExplosions.js
+++ b/server/src/light-programs/programs/musicExplosions.js
@@ -29,7 +29,8 @@ module.exports = class MusicExplosions extends LightProgram {
   }
 
   // Override parent method
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    let audio = context.audio;
     audio = audio.currentFrame || {};
     this.time += this.config.speed;
 
@@ -86,7 +87,9 @@ module.exports = class MusicExplosions extends LightProgram {
 
     this.explosions = this.explosions.filter(exp => exp.energy > 0.01);
 
-    draw(this.lastVolume);
+    leds.forEach((v, i) => {
+      leds[i] = this.lastVolume[i];
+    });
   }
 
   static presets() {

--- a/server/src/light-programs/programs/musicFlash.js
+++ b/server/src/light-programs/programs/musicFlash.js
@@ -9,7 +9,8 @@ module.exports = class MusicFlash extends LightProgram {
     this.maxVolume = 0;
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    let audio = context.audio;
     audio = audio.currentFrame || {};
     this.time += this.config.speed;
 
@@ -28,7 +29,9 @@ module.exports = class MusicFlash extends LightProgram {
       this.lastVolume[i] = newVal;
     }
 
-    draw(this.lastVolume);
+    leds.forEach((v, i) => {
+      leds[i] = this.lastVolume[i];
+    });
   }
 
   static presets() {

--- a/server/src/light-programs/programs/musicFlow.js
+++ b/server/src/light-programs/programs/musicFlow.js
@@ -11,7 +11,8 @@ module.exports = class MusicFlow extends LightProgram {
   }
 
   // Override parent method
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    let audio = context.audio;
     if (!audio.ready) {
       return;
     }
@@ -64,7 +65,9 @@ module.exports = class MusicFlow extends LightProgram {
       }
     }
 
-    draw(this.lastVolume);
+    leds.forEach((v, i) => {
+      leds[i] = this.lastVolume[i];
+    });
   }
 
   static presets() {

--- a/server/src/light-programs/programs/musicFrequencyDot.js
+++ b/server/src/light-programs/programs/musicFrequencyDot.js
@@ -13,7 +13,8 @@ module.exports = class MusicFrequencyDot extends LightProgram {
     this.densityInvariantLength = _.sumBy(this.geometry.density, v => 1/v);
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    let audio = context.audio;
     if (audio.ready) {
       let [,mic,,metric] = (this.config.soundMetric || 'bassPeakDecay') .match(/(\w+_)?(bass|mid|high)?(.+)/);
 
@@ -68,7 +69,9 @@ module.exports = class MusicFrequencyDot extends LightProgram {
 
     this.frameNumber++;
 
-    draw(this.lastVolume);
+    leds.forEach((v, i) => {
+      leds[i] = this.lastVolume[i];
+    });
   }
 
   static presets() {

--- a/server/src/light-programs/programs/musicVolumeBars.js
+++ b/server/src/light-programs/programs/musicVolumeBars.js
@@ -10,7 +10,8 @@ module.exports = class MusicVolumeBars extends LightProgram {
     this.maxVolume = 0;
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    let audio = context.audio;
     audio = audio.currentFrame || {};
     this.time += this.config.speed;
 
@@ -40,7 +41,9 @@ module.exports = class MusicVolumeBars extends LightProgram {
       this.lastVolume[i] = newColor;
     }
 
-    draw(this.lastVolume);
+    leds.forEach((v, i) => {
+      leds[i] = this.lastVolume[i];
+    });
   }
 
   static presets() {

--- a/server/src/light-programs/programs/musicVolumeDot.js
+++ b/server/src/light-programs/programs/musicVolumeDot.js
@@ -11,7 +11,8 @@ module.exports = class MusicVolumeDot extends LightProgram {
     this.densityInvariantLength = _.sumBy(this.geometry.density, v => 1/v);
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    let audio = context.audio;
     audio = audio.currentFrame || {};
     this.time += this.config.speed;
 
@@ -36,7 +37,9 @@ module.exports = class MusicVolumeDot extends LightProgram {
       densityInvariantPos += 1/this.geometry.density[i];
     }
 
-    draw(this.lastVolume);
+    leds.forEach((v, i) => {
+      leds[i] = this.lastVolume[i];
+    });
   }
 
   static presets() {

--- a/server/src/light-programs/programs/musicVolumeDotRandom.js
+++ b/server/src/light-programs/programs/musicVolumeDotRandom.js
@@ -21,7 +21,8 @@ module.exports = class MusicVolumeDotRandom extends LightProgram {
   }
 
   // Override parent method
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    let audio = context.audio;
     audio = audio.currentFrame || {};
     this.time += this.config.speed;
 
@@ -49,7 +50,9 @@ module.exports = class MusicVolumeDotRandom extends LightProgram {
       }
     }
 
-    draw(this.lastVolume);
+    leds.forEach((v, i) => {
+      leds[i] = this.lastVolume[i];
+    });
   }
 
   static presets() {

--- a/server/src/light-programs/programs/noise.js
+++ b/server/src/light-programs/programs/noise.js
@@ -24,7 +24,7 @@ module.exports = class Noise extends LightProgram {
     this.noise = new tumult[this.config.noise]();
   }
 
-  drawFrame(draw) {
+  drawFrame(leds) {
     this.timedMultiGradient.currentTime = this.timeInMs / 1000;
     this.time += this.config.speed;
 
@@ -35,8 +35,7 @@ module.exports = class Noise extends LightProgram {
     const { x, y } = this.geometry;
     const t = this.time / 1000;
 
-    var colors = new Array(this.numberOfLeds);
-    for (let i = 0; i < colors.length; i++) {
+    for (let i = 0; i < leds.length; i++) {
       const v = rescale(
         this.config.colorScale * this.gen(x[i] / 32 + t, y[i] / 32 + t)
       );
@@ -44,9 +43,8 @@ module.exports = class Noise extends LightProgram {
         this.config.brightnessScale *
           this.gen(x[i] / 32 + t + 100, y[i] / 32 + t)
       );
-      colors[i] = gradient.colorAt(v).map(x => Math.floor(x * brightness));
+      leds[i] = gradient.colorAt(v).map(x => Math.floor(x * brightness));
     }
-    draw(colors);
   }
 
   gen(x, y) {

--- a/server/src/light-programs/programs/radial.js
+++ b/server/src/light-programs/programs/radial.js
@@ -5,8 +5,7 @@ const ColorUtils = require("./../utils/ColorUtils");
 const {loadGradient} = require("../utils/gradients");
 
 module.exports = class Radial extends LightProgram {
-  drawFrame(draw) {
-    const colors = new Array(this.numberOfLeds);
+  drawFrame(leds) {
     const elapsed = this.timeInMs / 1000;
 
     this.extraTime = (this.extraTime || 0) + Math.random() * 10;
@@ -29,16 +28,15 @@ module.exports = class Radial extends LightProgram {
       if (this.config.colorMap) {
         const gradient = loadGradient(this.config.colorMap);
         const [r, g, b, a] = gradient.colorAt(1 - v);
-        colors[i] = [r, g, b];
+        leds[i] = [r, g, b];
       } else {
-        colors[i] = ColorUtils.HSVtoRGB(
+        leds[i] = ColorUtils.HSVtoRGB(
           (distance / 5 + this.extraTime / 1000) % 1,
           1,
           v
         );
       }
     }
-    draw(colors);
   }
 
   // Override and extend config Schema

--- a/server/src/light-programs/programs/radial3d.js
+++ b/server/src/light-programs/programs/radial3d.js
@@ -14,8 +14,7 @@ module.exports = class Radial3D extends LightProgram {
     super.init();
   }
 
-  drawFrame(draw) {
-    const colors = new Array(this.numberOfLeds);
+  drawFrame(leds) {
     const elapsed = this.timeInMs / 1000;
 
     const time = this.timeInMs / 1000;
@@ -39,9 +38,8 @@ module.exports = class Radial3D extends LightProgram {
       );
 
       const [r, g, b, a] = gradient.colorAt(1 - v);
-      colors[i] = [r*v, g*v, b*v];
+      leds[i] = [r*v, g*v, b*v];
     }
-    draw(colors);
   }
 
   // Override and extend config Schema

--- a/server/src/light-programs/programs/radialSun.js
+++ b/server/src/light-programs/programs/radialSun.js
@@ -14,13 +14,13 @@ module.exports = class RadialSun extends LightProgram {
     this.globalTop = this.geometry.height;
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    let audio = context.audio;
     if (!audio.ready) {
       return;
     }
 
     audio = audio.currentFrame;
-    const colors = new Array(this.numberOfLeds);
     const elapsed = this.timeInMs / 1000;
 
     const vol = audio[this.config.soundMetric] || Number.EPSILON;
@@ -64,16 +64,15 @@ module.exports = class RadialSun extends LightProgram {
 
       if(gradient) {
         const [r, g, b, a] = gradient.colorAt(1 - energy);
-        colors[i] = [energy*r,energy*g,energy*b,1]
+        leds[i] = [energy*r,energy*g,energy*b,1]
       } else {
-        colors[i] = ColorUtils.HSVtoRGB(
+        leds[i] = ColorUtils.HSVtoRGB(
             (this.baseHue + this.extraTime / 5000) % 1,
             this.config.saturation,
             energy
         );
       }
     }
-    draw(colors);
   }
 
   static presets() {

--- a/server/src/light-programs/programs/rainbow.js
+++ b/server/src/light-programs/programs/rainbow.js
@@ -22,11 +22,9 @@ module.exports = class Rainbow extends LightProgram {
     this.frame = 0;
   }
 
-  drawFrame(draw) {
+  drawFrame(leds) {
     this.time += this.config.speed;
     this.frame ++;
-
-    const newColors = new Array(this.numberOfLeds);
 
     for (let i = 0; i < this.numberOfLeds; i++) {
       let colIndex =
@@ -36,15 +34,14 @@ module.exports = class Rainbow extends LightProgram {
       let col = ColorUtils.hexToRgb(this.colorSet[colIndex]);
       if (colIndex === 6) {
         if(this.frame % 2 || !this.config.blink) {
-          newColors[i] = col;
+          leds[i] = col;
         } else {
-          newColors[i] = ColorUtils.hexToRgb('#FF0000');
+          leds[i] = ColorUtils.hexToRgb('#FF0000');
         }
       } else {
-        newColors[i] = ColorUtils.dim(col, this.config.brillo)
+        leds[i] = ColorUtils.dim(col, this.config.brillo)
       }
     }
-    draw(newColors);
   }
 
   static presets() {

--- a/server/src/light-programs/programs/rays.js
+++ b/server/src/light-programs/programs/rays.js
@@ -48,7 +48,8 @@ module.exports = class Rays extends LightProgram {
     }
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    const audio = context.audio
     // let decay = this.config.decay;
     this.time++;
     let decay = this.config.decay;
@@ -106,7 +107,9 @@ module.exports = class Rays extends LightProgram {
       }
     }
 
-    draw(this.stars);
+    leds.forEach((v, i) => {
+      leds[i] = this.stars[i];
+    });
   }
 
   static presets() {

--- a/server/src/light-programs/programs/relampejo.js
+++ b/server/src/light-programs/programs/relampejo.js
@@ -22,7 +22,8 @@ module.exports = class Stars extends LightProgram {
     })
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    const audio = context.audio;
     this.time++;
     let vol = ((audio.currentFrame || {})[this.config.soundMetric] || 0)
     if (vol < this.config.cutThreshold) {
@@ -67,7 +68,9 @@ module.exports = class Stars extends LightProgram {
       }
     }
 
-    draw(this.stars.map(([r, g, b]) => ColorUtils.dim([r, g, b], this.config.brillo)));
+    this.stars.forEach(([r, g, b], i) => {
+      leds[i] = ColorUtils.dim([r, g, b], this.config.brillo);
+    });
   }
 
   static presets() {

--- a/server/src/light-programs/programs/relampejo.js
+++ b/server/src/light-programs/programs/relampejo.js
@@ -33,7 +33,7 @@ module.exports = class Stars extends LightProgram {
       vol = 1;
     }
 
-    this.stars = new Array(this.numberOfLeds).fill([0, 0, 0]);
+    this.stars.fill([0, 0, 0]);
 
     for(const f of this.flashes) {
       for (let i = f.location; i < f.location+f.size; i++) {

--- a/server/src/light-programs/programs/sound-waves.js
+++ b/server/src/light-programs/programs/sound-waves.js
@@ -31,7 +31,8 @@ module.exports = class SoundWaves extends LightProgram {
     wave.intensity = wave.intensity * (intensityDecay + ((1 - intensityDecay) * Math.sqrt(wave.intensity)));
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    let audio = context.audio;
     if (!audio.ready) {
       return;
     }
@@ -58,7 +59,6 @@ module.exports = class SoundWaves extends LightProgram {
 
     let geometry = this.geometry;
 
-    const colors = _.map(new Array(this.numberOfLeds), c => [0, 0, 0]);
     for (let i = 0; i < this.numberOfLeds; i++) {
       let [r, g, b] = [0, 0, 0];
       _.each(this.dots, dot => {
@@ -90,12 +90,10 @@ module.exports = class SoundWaves extends LightProgram {
           }
         }
       });
-      colors[i] = ColorUtils.dim([r, g, b], this.config.brilloWave);
+      leds[i] = ColorUtils.dim([r, g, b], this.config.brilloWave);
     }
 
     _.each(this.dots, dot => this.updateWave(dot));
-
-    draw(colors);
   }
 
   static presets() {

--- a/server/src/light-programs/programs/speeding-spear.js
+++ b/server/src/light-programs/programs/speeding-spear.js
@@ -1,12 +1,12 @@
 const ColorSpear = require("./color-spear");
 
 module.exports = class SpeedingSpear extends ColorSpear {
-  drawFrame(draw) {
+  drawFrame(leds) {
     this.count = (this.count || 0) + 1;
     if (this.count % 180 == 0) {
       this.config.speed += 1;
       this.config.speed = Math.min(20, this.config.speed);
     }
-    super.drawFrame(draw);
+    super.drawFrame(leds);
   }
 };

--- a/server/src/light-programs/programs/stars.js
+++ b/server/src/light-programs/programs/stars.js
@@ -8,7 +8,7 @@ module.exports = class Stars extends LightProgram {
     this.time = 0;
   }
 
-  drawFrame(draw) {
+  drawFrame(leds) {
     let decay = this.config.decay;
     this.time++;
 
@@ -33,11 +33,9 @@ module.exports = class Stars extends LightProgram {
       let first = this.stars.shift();
       this.stars.push(first);
     }
-    draw(
-      this.stars.map(([r, g, b]) =>
-        ColorUtils.dim([r, g, b], this.config.brillo)
-      )
-    );
+    this.stars.forEach(([r, g, b], i) => {
+      leds[i] = ColorUtils.dim([r, g, b], this.config.brillo)
+    });
   }
 
   static presets() {

--- a/server/src/light-programs/programs/stripe-patterns.js
+++ b/server/src/light-programs/programs/stripe-patterns.js
@@ -57,9 +57,9 @@ module.exports = class StripePattern extends LightProgram {
     }
   }
 
-  drawFrame(draw, audio) {
+  drawFrame(leds, context) {
+    const audio = context.audio;
     this.time += this.config.speed;
-    const newColors = new Array(this.numberOfLeds);
 
     if (audio.ready) {
       this.rebuildPattern(audio.currentFrame);
@@ -69,11 +69,10 @@ module.exports = class StripePattern extends LightProgram {
     }
 
     for (let i = 0; i < this.numberOfLeds; i++) {
-      newColors[i] = this.pattern[
+      leds[i] = this.pattern[
         (i + Math.floor(this.time)) % this.pattern.length
       ];
     }
-    draw(newColors);
   }
 
   static presets() {

--- a/server/src/light-programs/programs/water-flood.js
+++ b/server/src/light-programs/programs/water-flood.js
@@ -9,8 +9,8 @@ module.exports = class WaterFlood extends LightProgram {
     this.waterLevel = 0.5;
   }
 
-  drawFrame(draw, audio) {
-    const colors = new Array(this.numberOfLeds);
+  drawFrame(leds, context) {
+    const audio = context.audio;
     const geometry = this.geometry;
 
     if (!audio.ready) {
@@ -28,7 +28,7 @@ module.exports = class WaterFlood extends LightProgram {
         posY < volumeHeight &&
         posY > volumeHeight * whiteBorderWidth
       ) {
-        colors[i] = [100, 100, 100];
+        leds[i] = [100, 100, 100];
       } else if (posY < volumeHeight) {
         let timeY = Math.sin(
           geometry.y[i] * this.config.escala +
@@ -38,17 +38,16 @@ module.exports = class WaterFlood extends LightProgram {
           geometry.x[i] * this.config.escala +
             (this.timeInMs * this.config.velocidad) / 20
         );
-        colors[i] = ColorUtils.HSVtoRGB(
+        leds[i] = ColorUtils.HSVtoRGB(
           this.config.color + 0.6 + (timeX * 0.05 + 0.025),
           1,
           Math.max(0, timeY + 0.7)
         );
       } else {
-        colors[i] = [0, 0, 0];
+        leds[i] = [0, 0, 0];
       }
     }
 
-    draw(colors);
   }
 
   static presets() {

--- a/server/src/light-programs/programs/waveform.js
+++ b/server/src/light-programs/programs/waveform.js
@@ -13,8 +13,8 @@ module.exports = class Waveform extends LightProgram {
     this.max = 0;
   }
 
-  drawFrame(draw, audio) {
-    const colors = new Array(this.numberOfLeds);
+  drawFrame(leds, context) {
+    const audio = context.audio;
 
     const frame = audio.currentFrame;
     if (!frame) {
@@ -34,12 +34,10 @@ module.exports = class Waveform extends LightProgram {
       const absSample = absSamples[index];
       const gradientPos = 0.5 * (sample / this.max) + 0.5;
       const brightness = absSample / this.max;
-      colors[i] = gradient
+      leds[i] = gradient
         .colorAt(gradientPos)
         .map(x => Math.floor(x * brightness));
     }
-
-    draw(colors);
   }
 
   static presets() {

--- a/server/src/light-programs/utils/ColorUtils.js
+++ b/server/src/light-programs/utils/ColorUtils.js
@@ -95,7 +95,15 @@ function hexToRgb(hexColor) {
   return [r, g, b, 1];
 }
 
-function mix([r, g, b, a], [r2, g2, b2, a2], ratio) {
+function mix(c1, c2, ratio) {
+  if (ratio <= 0) {
+    return c1;
+  }
+  if (ratio >= 1) {
+    return c2;
+  }
+  let [r, g, b, a] = c1;
+  let [r2, g2, b2, a2] = c2;
   a = a === undefined ? 1 : a;
   a2 = a2 === undefined ? 1 : a2;
   return [
@@ -116,12 +124,15 @@ function clamp(r, g, b, a) {
   ];
 }
 
-function dim([r, g, b, a], number) {
+function dim(color, number) {
+  if (number == 1) {
+    return color;
+  }
+  let [r, g, b, a] = color;
   r = Math.floor(r * number);
   g = Math.floor(g * number);
   b = Math.floor(b * number);
-  a = a === undefined ? 1 : a;
-  return [r, g, b, a];
+  return a === undefined ? [r, g, b] : [r, g, b, a];
 }
 
 // Modulo that handles negative numbers better.

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -135,6 +135,11 @@
   resolved "https://registry.yarnpkg.com/@types/xmldom/-/xmldom-0.1.29.tgz#c4428b0ca86d3b881475726fd94980b38a27c381"
   integrity sha1-xEKLDKhtO4gUdXJv2UmAs4onw4E=
 
+accurate-game-loop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/accurate-game-loop/-/accurate-game-loop-2.0.0.tgz#2a378fc061ebe0f446861518528a094fdc9f230d"
+  integrity sha512-JIftZhFffBoxGZZiwv0Y4nHme16LkPq6oblYqn0k5/iQCvUCqE4vpqI4Uc+C7utsyzKmY8jD0WUgHjCJa9uhpQ==
+
 acorn-jsx@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
@@ -1871,11 +1876,6 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-nanotimer@^0.3.15:
-  version "0.3.15"
-  resolved "https://registry.yarnpkg.com/nanotimer/-/nanotimer-0.3.15.tgz#280d277db9146eca6f8a570b572abaf2a9acc754"
-  integrity sha1-KA0nfbkUbspvilcLVyq68qmsx1Q=
 
 napi-build-utils@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
* Synchronous API (no "draw" callback). LightPrograms aren't supposed
  to do any async work anyway so this isn't needed. Implementation is
  much simpler and readable now.
* Receives leds array as input. This means that in most cases drawFrame
  doesn't need to allocate any memory each frame.
  * Known exceptions: programs that combine the output of inner
    sub-programs, in which case they should allocate one buffer per
    sub-program.
  * Overall this reduces pressure on the garbage collector tremendously.
* Receives extensible "context" object instead of just audio. We can use
  this to cleanup the timeInMs thing in the future.
* Replace nanotimer with accurate-game-loop library. nanotimer had a bug that could cause infinite recursion / stack overflow.
* Several CPU and memory optimizations. Everything runs smoother now.